### PR TITLE
read web.xml service classes if none are passed in

### DIFF
--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GenApiConfigAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GenApiConfigAction.java
@@ -56,12 +56,13 @@ public class GenApiConfigAction extends EndpointsToolAction {
 
   @Override
   public boolean execute() throws ClassNotFoundException, IOException, ApiConfigException {
-    if (getArgs().isEmpty()) {
+    String warPath = getWarPath(warOption);
+    List<String> serviceClassNames = getServiceClassNames(warPath);
+    if (serviceClassNames.isEmpty()) {
       return false;
     }
-    String warPath = getWarPath(warOption);
     genApiConfig(computeClassPath(warPath, getClassPath(classPathOption)),
-        getWarOutputPath(outputOption, warPath), warPath, getArgs(), true);
+        getWarOutputPath(outputOption, warPath), warPath, serviceClassNames, true);
     return true;
   }
 

--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetClientLibAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetClientLibAction.java
@@ -56,12 +56,13 @@ public class GetClientLibAction extends EndpointsToolAction {
 
   @Override
   public boolean execute() throws ClassNotFoundException, IOException, ApiConfigException {
-    if (getArgs().isEmpty()) {
+    String warPath = getWarPath(warOption);
+    List<String> serviceClassNames = getServiceClassNames(warPath);
+    if (serviceClassNames.isEmpty()) {
       return false;
     }
-    String warPath = getWarPath(warOption);
     getClientLib(computeClassPath(warPath, getClassPath(classPathOption)),
-        getLanguage(languageOption), getOutputPath(outputOption), warPath, getArgs(),
+        getLanguage(languageOption), getOutputPath(outputOption), warPath, serviceClassNames,
         getBuildSystem(buildSystemOption), getDebug(debugOption));
     return true;
   }

--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetDiscoveryDocAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetDiscoveryDocAction.java
@@ -55,13 +55,14 @@ public class GetDiscoveryDocAction extends EndpointsToolAction {
 
   @Override
   public boolean execute() throws ClassNotFoundException, IOException, ApiConfigException {
-    if (getArgs().isEmpty()) {
+    String warPath = getWarPath(warOption);
+    List<String> serviceClassNames = getServiceClassNames(warPath);
+    if (serviceClassNames.isEmpty()) {
       return false;
     }
-    String warPath = getWarPath(warOption);
     Format format = Format.valueOf(getFormat(formatOption).toUpperCase());
     getDiscoveryDoc(format, computeClassPath(warPath, getClassPath(classPathOption)),
-        getOutputPath(outputOption), warPath, getArgs(), getDebug(debugOption));
+        getOutputPath(outputOption), warPath, serviceClassNames, getDebug(debugOption));
     return true;
   }
 

--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetSwaggerDocAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetSwaggerDocAction.java
@@ -69,13 +69,14 @@ public class GetSwaggerDocAction extends EndpointsToolAction {
 
   @Override
   public boolean execute() throws ClassNotFoundException, IOException, ApiConfigException {
-    if (getArgs().isEmpty()) {
+    String warPath = getWarPath(warOption);
+    List<String> serviceClassNames = getServiceClassNames(warPath);
+    if (serviceClassNames.isEmpty()) {
       return false;
     }
-    String warPath = getWarPath(warOption);
     genSwaggerDoc(computeClassPath(warPath, getClassPath(classPathOption)),
         getSwaggerOutputPath(outputOption), getHostname(hostnameOption, warPath),
-        getBasePath(basePathOption), getArgs(), true);
+        getBasePath(basePathOption), serviceClassNames, true);
     return true;
   }
 

--- a/endpoints-framework-tools/src/test/resources/com/google/api/server/spi/tools/web.xml
+++ b/endpoints-framework-tools/src/test/resources/com/google/api/server/spi/tools/web.xml
@@ -1,0 +1,49 @@
+<!--
+Copyright 2016 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<web-app version='2.5' xmlns='http://java.sun.com/xml/ns/javaee' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd'>
+  <servlet>
+    <servlet-name>com.google.api.server.spi.EndpointsServlet</servlet-name>
+    <servlet-class>com.google.api.server.spi.EndpointsServlet</servlet-class>
+    <init-param>
+      <param-name>services</param-name>
+      <param-value>com.google.testapi.TestEndpoint,com.google.waxapi.WaxEndpoint</param-value>
+    </init-param>
+    <init-param>
+      <param-name>restricted</param-name>
+      <param-value>false</param-value>
+    </init-param>
+    <init-param>
+      <param-name>closed</param-name>
+      <param-value>true</param-value>
+    </init-param>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>com.google.api.server.spi.EndpointsServlet</servlet-name>
+    <url-pattern>/_ah/api/*</url-pattern>
+  </servlet-mapping>
+  <listener>
+    <listener-class>com.google.waxapi.ObjectifyInitializer</listener-class>
+  </listener>
+  <filter>
+    <filter-name>ObjectifyFilter</filter-name>
+    <filter-class>com.googlecode.objectify.ObjectifyFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>ObjectifyFilter</filter-name>
+    <url-pattern>/_ah/api/*</url-pattern>
+  </filter-mapping>
+</web-app>


### PR DESCRIPTION
The command line tools currently require the user to type in the service
class names to generate API configuration. This change makes it so that
if the user doesn't specify any classes, it attempts to read the
information from the web.xml instead.