### PR TITLE
Fix build on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,14 @@ subprojects {
     // Workaround to actually apply project compatibility
     sourceCompatibility = project.sourceCompatibility
     targetCompatibility = project.targetCompatibility
+    options.encoding = 'UTF-8'
   }
 
   compileTestJava {
     // Workaround to actually apply project compatibility
     sourceCompatibility = project.sourceCompatibility
     targetCompatibility = project.targetCompatibility
+    options.encoding = 'UTF-8'
   }
 
   test {

--- a/endpoints-framework-tools/src/test/java/com/google/api/server/spi/tools/EndpointsToolActionTest.java
+++ b/endpoints-framework-tools/src/test/java/com/google/api/server/spi/tools/EndpointsToolActionTest.java
@@ -218,9 +218,9 @@ public class EndpointsToolActionTest {
 
     TestAction action = new TestAction();
     URL[] urls = action.computeClassPath(tempDir, jarFileInClasspath.getAbsolutePath());
-    assertEquals(classesDir.getAbsolutePath() + File.separator, urls[0].getFile());
-    assertEquals(jarFileInLibDir.getAbsolutePath(), urls[1].getFile());
-    assertEquals(jarFileInClasspath.getAbsolutePath(), urls[2].getFile());
+    assertEquals(new File(classesDir.getAbsolutePath() + File.separator), new File(urls[0].getFile()));
+    assertEquals(new File(jarFileInLibDir.getAbsolutePath()), new File(urls[1].getFile()));
+    assertEquals(new File(jarFileInClasspath.getAbsolutePath()), new File(urls[2].getFile()));
   }
 
   @Test

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/ApiNamespace.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/ApiNamespace.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 public @interface ApiNamespace {
   /**
    * This is the domain name commonly associated with owner.
-   * If, for instance, this is an API owned by NASA, then “nasa.gov” would be a reasonable choice
+   * If, for instance, this is an API owned by NASA, then "nasa.gov" would be a reasonable choice
    * for domain name.
    * It does not necessarily need to be the same as the serving domain, though the latter will be
    * picked as a default if {@code ownerDomain} is not set.
@@ -41,7 +41,7 @@ public @interface ApiNamespace {
    * This is a canonical company name obeying the same rules as the canonical API name.
    * It obeys the exact capitalization a company would like to use to represent themselves.
    * If their name is really two dwords, they are separated by spaces.
-   * E.g. “YouTube”, “NASA” , “3Com”, “Fox News”.
+   * E.g. "YouTube", "NASA" , "3Com", "Fox News".
    *
    * Required for a specified namespace.
    */


### PR DESCRIPTION
- Define source encoding in gradle
- Fix tests assuming file separator is /
- Remove non-UTF-8 chars in Javadoc (couldn't find an easy way to tell the gradle javadoc command to use UTF-8)