### PR TITLE
Use "https://accounts.google.com" as issuer to validate JWT tokens

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/Constant.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/Constant.java
@@ -61,7 +61,12 @@ public final class Constant {
   public static final String DISCOVERY_GEN_ROOT = "https://webapis-discovery.appspot.com/_ah/api";
 
   /**
-   * Friendly name to refer to Google ID token authentication.
+   * Friendly name to refer to Google ID token authentication with accounts.google.com issuer.
    */
   public static final String GOOGLE_ID_TOKEN_NAME = "google_id_token";
+
+  /**
+   * Google ID token authentication variant with https://accounts.google.com issuer.
+   */
+  public static final String GOOGLE_ID_TOKEN_NAME_HTTPS = "google_id_token_https";
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/IssuerUtil.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/IssuerUtil.java
@@ -57,7 +57,7 @@ public class IssuerUtil {
     }
     if (!googleAudiencesUnspecified) {
       builder.addIssuerAudiences(Constant.GOOGLE_ID_TOKEN_NAME, googleAudiences);
-      builder.addIssuerAudiences(Constant.GOOGLE_ID_TOKEN_NAME + "_alt", googleAudiences);
+      builder.addIssuerAudiences(Constant.GOOGLE_ID_TOKEN_NAME_HTTPS, googleAudiences);
     }
     return builder.build();
   }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/IssuerUtil.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/IssuerUtil.java
@@ -57,6 +57,7 @@ public class IssuerUtil {
     }
     if (!googleAudiencesUnspecified) {
       builder.addIssuerAudiences(Constant.GOOGLE_ID_TOKEN_NAME, googleAudiences);
+      builder.addIssuerAudiences(Constant.GOOGLE_ID_TOKEN_NAME + "_alt", googleAudiences);
     }
     return builder.build();
   }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiIssuerConfigs.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiIssuerConfigs.java
@@ -11,7 +11,10 @@ import java.util.Objects;
 public class ApiIssuerConfigs {
   static final String UNSPECIFIED_NAME = "_unspecified_issuer_name";
   public static final IssuerConfig GOOGLE_ID_TOKEN_ISSUER = new IssuerConfig(
-      Constant.GOOGLE_ID_TOKEN_NAME, "https://accounts.google.com",
+      Constant.GOOGLE_ID_TOKEN_NAME, "accounts.google.com",
+      "https://www.googleapis.com/oauth2/v1/certs");
+  public static final IssuerConfig GOOGLE_ID_TOKEN_ISSUER_ALT = new IssuerConfig(
+      Constant.GOOGLE_ID_TOKEN_NAME + "_alt", "https://accounts.google.com",
       "https://www.googleapis.com/oauth2/v1/certs");
   public static final ApiIssuerConfigs UNSPECIFIED = builder()
       .addIssuer(new IssuerConfig(UNSPECIFIED_NAME, null, null))
@@ -36,7 +39,8 @@ public class ApiIssuerConfigs {
   }
 
   public ApiIssuerConfigs withGoogleIdToken() {
-    if (hasIssuer(Constant.GOOGLE_ID_TOKEN_NAME)) {
+    if (hasIssuer(Constant.GOOGLE_ID_TOKEN_NAME) 
+        && hasIssuer(Constant.GOOGLE_ID_TOKEN_NAME + "_alt")) {
       return this;
     }
     Builder builder = builder();
@@ -44,6 +48,7 @@ public class ApiIssuerConfigs {
       builder.issuerConfigs.putAll(issuerConfigs);
     }
     builder.addIssuer(GOOGLE_ID_TOKEN_ISSUER);
+    builder.addIssuer(GOOGLE_ID_TOKEN_ISSUER_ALT);
     return builder.build();
   }
 

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiIssuerConfigs.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiIssuerConfigs.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 public class ApiIssuerConfigs {
   static final String UNSPECIFIED_NAME = "_unspecified_issuer_name";
   public static final IssuerConfig GOOGLE_ID_TOKEN_ISSUER = new IssuerConfig(
-      Constant.GOOGLE_ID_TOKEN_NAME, "accounts.google.com",
+      Constant.GOOGLE_ID_TOKEN_NAME, "https://accounts.google.com",
       "https://www.googleapis.com/oauth2/v1/certs");
   public static final ApiIssuerConfigs UNSPECIFIED = builder()
       .addIssuer(new IssuerConfig(UNSPECIFIED_NAME, null, null))

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiIssuerConfigs.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiIssuerConfigs.java
@@ -14,7 +14,7 @@ public class ApiIssuerConfigs {
       Constant.GOOGLE_ID_TOKEN_NAME, "accounts.google.com",
       "https://www.googleapis.com/oauth2/v1/certs");
   public static final IssuerConfig GOOGLE_ID_TOKEN_ISSUER_ALT = new IssuerConfig(
-      Constant.GOOGLE_ID_TOKEN_NAME + "_alt", "https://accounts.google.com",
+      Constant.GOOGLE_ID_TOKEN_NAME_HTTPS, "https://accounts.google.com",
       "https://www.googleapis.com/oauth2/v1/certs");
   public static final ApiIssuerConfigs UNSPECIFIED = builder()
       .addIssuer(new IssuerConfig(UNSPECIFIED_NAME, null, null))
@@ -40,7 +40,7 @@ public class ApiIssuerConfigs {
 
   public ApiIssuerConfigs withGoogleIdToken() {
     if (hasIssuer(Constant.GOOGLE_ID_TOKEN_NAME) 
-        && hasIssuer(Constant.GOOGLE_ID_TOKEN_NAME + "_alt")) {
+        && hasIssuer(Constant.GOOGLE_ID_TOKEN_NAME_HTTPS)) {
       return this;
     }
     Builder builder = builder();

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
@@ -106,7 +106,7 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "accounts.google.com",
+      "x-issuer": "https://accounts.google.com",
       "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     }
   }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
@@ -35,7 +35,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       },
@@ -59,7 +59,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       },
@@ -83,7 +83,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       },
@@ -107,7 +107,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       }
@@ -121,7 +121,7 @@
       "x-issuer": "accounts.google.com",
       "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     },
-    "google_id_token_alt": {
+    "google_id_token_https": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
@@ -33,6 +33,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       },
@@ -54,6 +57,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       },
@@ -75,6 +81,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       },
@@ -96,6 +105,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       }
@@ -103,6 +115,13 @@
   },
   "securityDefinitions": {
     "google_id_token": {
+      "type": "oauth2",
+      "authorizationUrl": "",
+      "flow": "implicit",
+      "x-issuer": "accounts.google.com",
+      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+    },
+    "google_id_token_alt": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
@@ -37,7 +37,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       },
@@ -61,7 +61,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       },
@@ -85,7 +85,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       },
@@ -109,7 +109,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       }
@@ -123,7 +123,7 @@
       "x-issuer": "accounts.google.com",
       "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     },
-    "google_id_token_alt": {
+    "google_id_token_https": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
@@ -108,7 +108,7 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "accounts.google.com",
+      "x-issuer": "https://accounts.google.com",
       "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     }
   }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
@@ -35,6 +35,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       },
@@ -56,6 +59,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       },
@@ -77,6 +83,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       },
@@ -98,6 +107,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       }
@@ -105,6 +117,13 @@
   },
   "securityDefinitions": {
     "google_id_token": {
+      "type": "oauth2",
+      "authorizationUrl": "",
+      "flow": "implicit",
+      "x-issuer": "accounts.google.com",
+      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+    },
+    "google_id_token_alt": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
@@ -37,7 +37,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ],
         "x-security": [
@@ -49,7 +49,7 @@
             }
           },
           {
-            "google_id_token_alt": {
+            "google_id_token_https": {
               "audiences": [
                 "audience"
               ]
@@ -77,7 +77,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ],
         "x-security": [
@@ -89,7 +89,7 @@
             }
           },
           {
-            "google_id_token_alt": {
+            "google_id_token_https": {
               "audiences": [
                 "audience"
               ]
@@ -117,7 +117,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ],
         "x-security": [
@@ -129,7 +129,7 @@
             }
           },
           {
-            "google_id_token_alt": {
+            "google_id_token_https": {
               "audiences": [
                 "audience"
               ]
@@ -157,7 +157,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ],
         "x-security": [
@@ -169,7 +169,7 @@
             }
           },
           {
-            "google_id_token_alt": {
+            "google_id_token_https": {
               "audiences": [
                 "audience"
               ]
@@ -187,7 +187,7 @@
       "x-issuer": "accounts.google.com",
       "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     },
-    "google_id_token_alt": {
+    "google_id_token_https": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
@@ -35,11 +35,21 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ],
         "x-security": [
           {
             "google_id_token": {
+              "audiences": [
+                "audience"
+              ]
+            }
+          },
+          {
+            "google_id_token_alt": {
               "audiences": [
                 "audience"
               ]
@@ -65,11 +75,21 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ],
         "x-security": [
           {
             "google_id_token": {
+              "audiences": [
+                "audience"
+              ]
+            }
+          },
+          {
+            "google_id_token_alt": {
               "audiences": [
                 "audience"
               ]
@@ -95,11 +115,21 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ],
         "x-security": [
           {
             "google_id_token": {
+              "audiences": [
+                "audience"
+              ]
+            }
+          },
+          {
+            "google_id_token_alt": {
               "audiences": [
                 "audience"
               ]
@@ -125,11 +155,21 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ],
         "x-security": [
           {
             "google_id_token": {
+              "audiences": [
+                "audience"
+              ]
+            }
+          },
+          {
+            "google_id_token_alt": {
               "audiences": [
                 "audience"
               ]
@@ -141,6 +181,13 @@
   },
   "securityDefinitions": {
     "google_id_token": {
+      "type": "oauth2",
+      "authorizationUrl": "",
+      "flow": "implicit",
+      "x-issuer": "accounts.google.com",
+      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+    },
+    "google_id_token_alt": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
@@ -144,7 +144,7 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "accounts.google.com",
+      "x-issuer": "https://accounts.google.com",
       "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     }
   }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
@@ -37,7 +37,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       },
@@ -61,7 +61,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       },
@@ -85,7 +85,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       },
@@ -109,7 +109,7 @@
             "google_id_token": []
           },
           {
-            "google_id_token_alt": []
+            "google_id_token_https": []
           }
         ]
       }
@@ -123,7 +123,7 @@
       "x-issuer": "accounts.google.com",
       "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     },
-    "google_id_token_alt": {
+    "google_id_token_https": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
@@ -108,7 +108,7 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "accounts.google.com",
+      "x-issuer": "https://accounts.google.com",
       "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     }
   }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
@@ -35,6 +35,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       },
@@ -56,6 +59,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       },
@@ -77,6 +83,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       },
@@ -98,6 +107,9 @@
         "security": [
           {
             "google_id_token": []
+          },
+          {
+            "google_id_token_alt": []
           }
         ]
       }
@@ -105,6 +117,13 @@
   },
   "securityDefinitions": {
     "google_id_token": {
+      "type": "oauth2",
+      "authorizationUrl": "",
+      "flow": "implicit",
+      "x-issuer": "accounts.google.com",
+      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+    },
+    "google_id_token_alt": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
@@ -113,7 +113,7 @@
       "x-issuer": "accounts.google.com",
       "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     },
-    "google_id_token_alt": {
+    "google_id_token_https": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
@@ -110,6 +110,13 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
+      "x-issuer": "accounts.google.com",
+      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+    },
+    "google_id_token_alt": {
+      "type": "oauth2",
+      "authorizationUrl": "",
+      "flow": "implicit",
       "x-issuer": "https://accounts.google.com",
       "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
@@ -110,7 +110,7 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "accounts.google.com",
+      "x-issuer": "https://accounts.google.com",
       "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     }
   }


### PR DESCRIPTION
All the JWT tokens issued by Google currently have https://accounts.google.com as their issuer.
Below is an example of a JWT token generated today using the OAuth2 playground.
```
{
  "iss": "https://accounts.google.com",
  "at_hash": "***",
  "aud": "***",
  "sub": "***",
  "email_verified": true,
  "azp": "***",
  "hd": "***",
  "email": "***",
  "iat": 1476203989,
  "exp": 1476207589
}
```
It seems like the issuer has been changing back and forth from "accounts.google.com" to "https://accounts.google.com" recently (see my comment on [this post](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/google-cloud-endpoints/Rkfi0yMU93E/AGfMXB4ECQAJ))

This change switches back to https://accounts.google.com as the issuer, it fixes the [endpoints v2 backend sample](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/appengine/endpoints-frameworks-v2/backend).