### PR TITLE
add support for API keys in Swagger generation

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/Api.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/Api.java
@@ -192,4 +192,10 @@ public @interface Api {
    * by extension, the API Explorer.
    */
   AnnotationBoolean discoverable() default AnnotationBoolean.UNSPECIFIED;
+
+  /**
+   * Whether or not an API key is required. This is used to output a Swagger specification and has
+   * no effect unless used with endpoints-management-control-appengine.
+   */
+  AnnotationBoolean apiKeyRequired() default AnnotationBoolean.UNSPECIFIED;
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/ApiClass.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/ApiClass.java
@@ -88,4 +88,10 @@ public @interface ApiClass {
    * appengine datastore.
    */
   AnnotationBoolean useDatastoreForAdditionalConfig() default AnnotationBoolean.UNSPECIFIED;
+
+  /**
+   * Whether or not an API key is required. This is used to output a Swagger specification and has
+   * no effect unless used with endpoints-management-control-appengine.
+   */
+  AnnotationBoolean apiKeyRequired() default AnnotationBoolean.UNSPECIFIED;
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/ApiMethod.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/ApiMethod.java
@@ -116,4 +116,10 @@ public @interface ApiMethod {
    * Whether or not API method should be ignored.
    */
   AnnotationBoolean ignored() default AnnotationBoolean.UNSPECIFIED;
+
+  /**
+   * Whether or not an API key is required. This is used to output a Swagger specification and has
+   * no effect unless used with endpoints-management-control-appengine.
+   */
+  AnnotationBoolean apiKeyRequired() default AnnotationBoolean.UNSPECIFIED;
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiAnnotationConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiAnnotationConfig.java
@@ -178,4 +178,12 @@ class ApiAnnotationConfig {
       config.setPeerAuthenticators(Arrays.asList(peerAuthenticators));
     }
   }
+
+  public void setApiKeyRequiredIfSpecified(AnnotationBoolean apiKeyRequired) {
+    if (apiKeyRequired == AnnotationBoolean.TRUE) {
+      config.setApiKeyRequired(true);
+    } else if (apiKeyRequired == AnnotationBoolean.FALSE) {
+      config.setApiKeyRequired(false);
+    }
+  }
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiClassAnnotationConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiClassAnnotationConfig.java
@@ -93,4 +93,12 @@ public class ApiClassAnnotationConfig {
       config.setUseDatastore(false);
     }
   }
+
+  public void setApiKeyRequiredIfSpecified(AnnotationBoolean apiKeyRequired) {
+    if (apiKeyRequired == AnnotationBoolean.TRUE) {
+      config.setApiKeyRequired(true);
+    } else if (apiKeyRequired == AnnotationBoolean.FALSE) {
+      config.setApiKeyRequired(false);
+    }
+  }
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReader.java
@@ -206,6 +206,8 @@ public class ApiConfigAnnotationReader implements ApiConfigSource {
         this.<Class<? extends Authenticator>[]>getAnnotationProperty(api, "authenticators"));
     config.setPeerAuthenticatorsIfSpecified(this
         .<Class<? extends PeerAuthenticator>[]>getAnnotationProperty(api, "peerAuthenticators"));
+    config.setApiKeyRequiredIfSpecified(
+        (AnnotationBoolean) this.getAnnotationProperty(api, "apiKeyRequired"));
   }
 
   private ApiIssuerConfigs getIssuerConfigs(Annotation annotation)
@@ -298,6 +300,8 @@ public class ApiConfigAnnotationReader implements ApiConfigSource {
         Class<? extends PeerAuthenticator>[]>getAnnotationProperty(apiClass, "peerAuthenticators"));
     config.setUseDatastoreIfSpecified(
         (AnnotationBoolean) getAnnotationProperty(apiClass, "useDatastoreForAdditionalConfig"));
+    config.setApiKeyRequiredIfSpecified(
+        (AnnotationBoolean) this.getAnnotationProperty(apiClass, "apiKeyRequired"));
   }
 
   private void readEndpointMethods(Class<?> endpointClass,
@@ -349,6 +353,8 @@ public class ApiConfigAnnotationReader implements ApiConfigSource {
         Class<? extends PeerAuthenticator>[]>getAnnotationProperty(apiMethod,
         "peerAuthenticators"));
     config.setIgnoredIfSpecified((AnnotationBoolean) getAnnotationProperty(apiMethod, "ignored"));
+    config.setApiKeyRequiredIfSpecified(
+        (AnnotationBoolean) this.getAnnotationProperty(apiMethod, "apiKeyRequired"));
   }
 
   private void readMethodRequestParameters(EndpointMethod endpointMethod,

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiMethodAnnotationConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiMethodAnnotationConfig.java
@@ -110,4 +110,12 @@ class ApiMethodAnnotationConfig {
       config.setIgnored(false);
     }
   }
+
+  public void setApiKeyRequiredIfSpecified(AnnotationBoolean apiKeyRequired) {
+    if (apiKeyRequired == AnnotationBoolean.TRUE) {
+      config.setApiKeyRequired(true);
+    } else if (apiKeyRequired == AnnotationBoolean.FALSE) {
+      config.setApiKeyRequired(false);
+    }
+  }
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiClassConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiClassConfig.java
@@ -53,6 +53,7 @@ public class ApiClassConfig {
   private List<String> clientIds;
   private List<Class<? extends Authenticator>> authenticators;
   private List<Class<? extends PeerAuthenticator>> peerAuthenticators;
+  private Boolean apiKeyRequired;
 
   private final MethodConfigMap methods;
 
@@ -71,6 +72,7 @@ public class ApiClassConfig {
     this.peerAuthenticators = null;
     this.useDatastore = null;
     this.methods = new MethodConfigMap(this);
+    this.apiKeyRequired = null;
   }
 
   public ApiClassConfig(ApiClassConfig original, ApiConfig apiConfig) {
@@ -90,6 +92,7 @@ public class ApiClassConfig {
         original.peerAuthenticators == null ? null : new ArrayList<>(original.peerAuthenticators);
     this.useDatastore = original.useDatastore;
     this.methods = new MethodConfigMap(original.methods, this);
+    this.apiKeyRequired = original.apiKeyRequired;
   }
 
   @Override
@@ -110,7 +113,8 @@ public class ApiClassConfig {
           Objects.equals(authenticators, config.authenticators) &&
           Objects.equals(peerAuthenticators, config.peerAuthenticators) &&
           Objects.equals(useDatastore, config.useDatastore) &&
-          methods.equals(config.methods);
+          methods.equals(config.methods) &&
+          Objects.equals(apiKeyRequired, config.apiKeyRequired);
     } else {
       return false;
     }
@@ -120,7 +124,7 @@ public class ApiClassConfig {
   public int hashCode() {
     return Objects.hash(apiClassJavaName, apiClassJavaSimpleName, typeLoader, resource,
         authLevel, scopeExpression, audiences, clientIds, authenticators, peerAuthenticators, 
-        useDatastore, methods, issuerAudiences);
+        useDatastore, methods, issuerAudiences, apiKeyRequired);
   }
 
   public ApiConfig getApiConfig() {
@@ -214,6 +218,14 @@ public class ApiClassConfig {
 
   public MethodConfigMap getMethods() {
     return methods;
+  }
+
+  public void setApiKeyRequired(boolean apiKeyRequired) {
+    this.apiKeyRequired = apiKeyRequired;
+  }
+
+  public boolean isApiKeyRequired() {
+    return apiKeyRequired != null ? apiKeyRequired : apiConfig.isApiKeyRequired();
   }
 
   /**

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiConfig.java
@@ -81,6 +81,7 @@ public class ApiConfig {
   private List<String> clientIds;
   private List<Class<? extends Authenticator>> authenticators;
   private List<Class<? extends PeerAuthenticator>> peerAuthenticators;
+  private boolean apiKeyRequired;
 
   private final ApiAuthConfig authConfig;
   private final ApiCacheControlConfig cacheControlConfig;
@@ -146,6 +147,7 @@ public class ApiConfig {
     this.clientIds = original.clientIds == null ? null : new ArrayList<>(original.clientIds);
     this.authenticators = original.authenticators;
     this.peerAuthenticators = original.peerAuthenticators;
+    this.apiKeyRequired = original.apiKeyRequired;
     this.authConfig = new ApiAuthConfig(original.authConfig);
     this.cacheControlConfig = new ApiCacheControlConfig(original.cacheControlConfig);
     this.frontendLimitsConfig = new ApiFrontendLimitsConfig(original.frontendLimitsConfig);
@@ -196,6 +198,7 @@ public class ApiConfig {
         .addIfInconsistent("clientIds", clientIds, config.clientIds)
         .addIfInconsistent("authenticators", authenticators, config.authenticators)
         .addIfInconsistent("peerAuthenticators", peerAuthenticators, config.peerAuthenticators)
+        .addIfInconsistent("apiKeyRequired", apiKeyRequired, config.apiKeyRequired)
         .addAll(authConfig.getConfigurationInconsistencies(config.authConfig))
         .addAll(cacheControlConfig.getConfigurationInconsistencies(config.cacheControlConfig))
         .addAll(frontendLimitsConfig.getConfigurationInconsistencies(config.frontendLimitsConfig))
@@ -210,7 +213,7 @@ public class ApiConfig {
         documentationLink, backendRoot, isAbstract, defaultVersion, discoverable, useDatastore,
         resource, authLevel, scopeExpression, audiences, clientIds, authenticators,
         peerAuthenticators, authConfig, cacheControlConfig, frontendLimitsConfig,
-        serializationConfig, apiClassConfig, issuers, issuerAudiences);
+        serializationConfig, apiClassConfig, issuers, issuerAudiences, apiKeyRequired);
   }
 
   /**
@@ -279,6 +282,7 @@ public class ApiConfig {
     clientIds = DEFAULT_CLIENT_IDS;
     authenticators = null;
     peerAuthenticators = null;
+    apiKeyRequired = false;
   }
 
   public ApiKey getApiKey() {
@@ -481,6 +485,14 @@ public class ApiConfig {
 
   public List<Class<? extends PeerAuthenticator>> getPeerAuthenticators() {
     return peerAuthenticators;
+  }
+
+  public void setApiKeyRequired(boolean apiKeyRequired) {
+    this.apiKeyRequired = apiKeyRequired;
+  }
+
+  public boolean isApiKeyRequired() {
+    return apiKeyRequired;
   }
 
   private String toHttps(String url) {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiMethodConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiMethodConfig.java
@@ -159,6 +159,7 @@ public class ApiMethodConfig {
   private List<Class<? extends Authenticator>> authenticators;
   private List<Class<? extends PeerAuthenticator>> peerAuthenticators;
   private boolean ignored = false;
+  private Boolean apiKeyRequired;
 
   private final TypeLoader typeLoader;
 
@@ -186,6 +187,7 @@ public class ApiMethodConfig {
     this.peerAuthenticators =
         original.peerAuthenticators == null ? null : new ArrayList<>(original.peerAuthenticators);
     this.ignored = original.ignored;
+    this.apiKeyRequired = original.apiKeyRequired;
     this.typeLoader = original.typeLoader;
 
     // Parameter configs are mutable, so we need to do a deep copy.
@@ -223,6 +225,7 @@ public class ApiMethodConfig {
     authenticators = null;
     peerAuthenticators = null;
     ignored = false;
+    apiKeyRequired = null;
   }
 
   private RestMethod getRestMethod(Method method) {
@@ -251,7 +254,8 @@ public class ApiMethodConfig {
           Objects.equals(authenticators, config.authenticators) &&
           Objects.equals(peerAuthenticators, config.peerAuthenticators) &&
           Objects.equals(typeLoader, config.typeLoader) &&
-          ignored == config.ignored;
+          ignored == config.ignored &&
+          apiKeyRequired == config.apiKeyRequired;
     } else {
       return false;
     }
@@ -261,7 +265,7 @@ public class ApiMethodConfig {
   public int hashCode() {
     return Objects.hash(endpointMethodName, parameterConfigs, name, path, httpMethod,
         scopeExpression, audiences, clientIds, authenticators, peerAuthenticators, typeLoader,
-        ignored, issuerAudiences);
+        ignored, issuerAudiences, apiKeyRequired);
   }
 
   public ApiClassConfig getApiClassConfig() {
@@ -443,6 +447,14 @@ public class ApiMethodConfig {
 
   public boolean isIgnored() {
     return ignored;
+  }
+
+  public void setApiKeyRequired(boolean apiKeyRequired) {
+    this.apiKeyRequired = apiKeyRequired;
+  }
+
+  public boolean isApiKeyRequired() {
+    return apiKeyRequired != null ? apiKeyRequired : apiClassConfig.isApiKeyRequired();
   }
 
   /**

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -51,6 +51,8 @@ import io.swagger.models.Path;
 import io.swagger.models.Response;
 import io.swagger.models.Scheme;
 import io.swagger.models.Swagger;
+import io.swagger.models.auth.ApiKeyAuthDefinition;
+import io.swagger.models.auth.In;
 import io.swagger.models.auth.OAuth2Definition;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 import io.swagger.models.parameters.PathParameter;
@@ -69,6 +71,8 @@ import io.swagger.models.properties.StringProperty;
  * Generates a {@link Swagger} object representing a set of {@link ApiConfig} objects.
  */
 public class SwaggerGenerator {
+  private static final String API_KEY = "api_key";
+  private static final String API_KEY_PARAM = "key";
   private static final Converter<String, String> CONVERTER =
       CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.UPPER_CAMEL);
   private static final ImmutableMap<Type, String> TYPE_TO_STRING_MAP =
@@ -217,6 +221,13 @@ public class SwaggerGenerator {
     }
     operation.response(200, new Response().description("A successful response"));
     writeAudiences(methodConfig, writeInternal, operation);
+    if (methodConfig.isApiKeyRequired()) {
+      operation.addSecurity(API_KEY, ImmutableList.<String>of());
+      Map<String, SecuritySchemeDefinition> definitions = swagger.getSecurityDefinitions();
+      if (definitions == null || !definitions.containsKey(API_KEY)) {
+        swagger.securityDefinition(API_KEY, new ApiKeyAuthDefinition(API_KEY_PARAM, In.QUERY));
+      }
+    }
     path.set(methodConfig.getHttpMethod().toLowerCase(), operation);
   }
 

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
@@ -21,6 +21,7 @@ import com.google.api.server.spi.Constant;
 import com.google.api.server.spi.IoUtil;
 import com.google.api.server.spi.ServiceContext;
 import com.google.api.server.spi.TypeLoader;
+import com.google.api.server.spi.config.AnnotationBoolean;
 import com.google.api.server.spi.config.Api;
 import com.google.api.server.spi.config.ApiConfigLoader;
 import com.google.api.server.spi.config.ApiIssuer;
@@ -130,6 +131,15 @@ public class SwaggerGeneratorTest {
     compareSwagger(expected, swagger);
   }
 
+  @Test
+  public void testWriteSwagger_ApiKeys() throws Exception {
+    ApiConfig config =
+        configLoader.loadConfiguration(ServiceContext.create(), ApiKeysEndpoint.class);
+    Swagger swagger = generator.writeSwagger(ImmutableList.of(config), true, context);
+    Swagger expected = readExpectedAsSwagger("api_keys.swagger");
+    compareSwagger(expected, swagger);
+  }
+
   private Swagger getSwagger(Class<?> serviceClass, SwaggerContext context, boolean internal)
       throws Exception {
     ApiConfig config = configLoader.loadConfiguration(ServiceContext.create(), serviceClass);
@@ -213,5 +223,15 @@ public class SwaggerGeneratorTest {
         }
     )
     public void googleAuth() { }
+  }
+
+  @Api(name = "apikeys", version = "v1",
+      apiKeyRequired = AnnotationBoolean.TRUE)
+  private static class ApiKeysEndpoint {
+    @ApiMethod(apiKeyRequired = AnnotationBoolean.FALSE)
+    public void overrideApiKeySetting() { }
+
+    @ApiMethod
+    public void inheritApiKeySetting() { }
   }
 }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/api_keys.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/api_keys.swagger
@@ -1,0 +1,54 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "swagger-test.appspot.com"
+  },
+  "host": "swagger-test.appspot.com",
+  "basePath": "/api",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/apikeys/v1/inheritApiKeySetting": {
+      "post": {
+        "operationId": "ApikeysInheritApiKeySetting",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A successful response"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/apikeys/v1/overrideApiKeySetting": {
+      "post": {
+        "operationId": "ApikeysOverrideApiKeySetting",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A successful response"
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "name": "key",
+      "in": "query"
+    }
+  }
+}


### PR DESCRIPTION
This change doesn't actually add API key validation, since that's done
in the endpoints-management libraries. This simply adds Swagger
generation so that the the management filter knows to do the validation.
To keep things simple, we provide a boolean true or false and fix the
API key to be a query parameter named "key". This is in line with what
client libraries expect.