### PR TITLE
de-couple new and old audiences in the model

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReader.java
@@ -217,8 +217,8 @@ public class ApiConfigAnnotationReader implements ApiConfigSource {
 
   private ApiIssuerAudienceConfig getIssuerAudiences(Annotation annotation)
       throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
-    return IssuerUtil.toConfig((ApiIssuerAudience[]) getAnnotationProperty(annotation, "issuerAudiences"),
-        (String[]) getAnnotationProperty(annotation, "audiences"));
+    return IssuerUtil.toConfig(
+        (ApiIssuerAudience[]) getAnnotationProperty(annotation, "issuerAudiences"));
   }
 
   private <T> T getAnnotationProperty(Annotation annotation, String name)

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/IssuerUtil.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/IssuerUtil.java
@@ -15,7 +15,6 @@
  */
 package com.google.api.server.spi.config.annotationreader;
 
-import com.google.api.server.spi.Constant;
 import com.google.api.server.spi.config.Api;
 import com.google.api.server.spi.config.ApiIssuer;
 import com.google.api.server.spi.config.ApiIssuerAudience;
@@ -42,22 +41,15 @@ public class IssuerUtil {
     return builder.build();
   }
 
-  public static ApiIssuerAudienceConfig toConfig(ApiIssuerAudience[] issuers, String[] googleAudiences) {
+  public static ApiIssuerAudienceConfig toConfig(ApiIssuerAudience[] issuers) {
     boolean thirdPartyIssuersUnspecified =
         issuers.length == 1 && Api.UNSPECIFIED_STRING_FOR_LIST.equals(issuers[0].name());
-    boolean googleAudiencesUnspecified = AnnotationUtil.isUnspecified(googleAudiences);
-    if (thirdPartyIssuersUnspecified && googleAudiencesUnspecified) {
+    if (thirdPartyIssuersUnspecified) {
       return ApiIssuerAudienceConfig.UNSPECIFIED;
     }
     ApiIssuerAudienceConfig.Builder builder = ApiIssuerAudienceConfig.builder();
-    if (!thirdPartyIssuersUnspecified) {
-      for (ApiIssuerAudience issuer : issuers) {
-        builder.addIssuerAudiences(issuer.name(), issuer.audiences());
-      }
-    }
-    if (!googleAudiencesUnspecified) {
-      builder.addIssuerAudiences(Constant.GOOGLE_ID_TOKEN_NAME, googleAudiences);
-      builder.addIssuerAudiences(Constant.GOOGLE_ID_TOKEN_NAME_HTTPS, googleAudiences);
+    for (ApiIssuerAudience issuer : issuers) {
+      builder.addIssuerAudiences(issuer.name(), issuer.audiences());
     }
     return builder.build();
   }


### PR DESCRIPTION
Right now, the legacy audiences directly impact the data structures used
for third party JWT issuers. However, if you add audiences below the
@Api level, then this means some ApiConfig objects will have Google
issuer configs and some will not. This change removes the effect of the
legacy audiences on the new and instead lets other code merge them as
necessary, to keep the model consistent.