### PR TITLE
fix get-client-lib action

### DIFF
--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetClientLibAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetClientLibAction.java
@@ -81,14 +81,10 @@ public class GetClientLibAction extends EndpointsToolAction {
   public Object getClientLib(URL[] classPath, String language, String outputDirPath,
       String warPath, List<String> serviceClassNames, String buildSystem, boolean debug)
           throws ClassNotFoundException, IOException, ApiConfigException {
-    Iterable<String> apiConfigs = new GenApiConfigAction().genApiConfig(classPath, outputDirPath,
-        warPath, serviceClassNames, debug);
     Map<String, String> discoveryDocs = new GetDiscoveryDocAction().getDiscoveryDoc(
         classPath, outputDirPath, warPath, serviceClassNames, debug);
     for (Map.Entry<String, String> entry : discoveryDocs.entrySet()) {
-      String restDiscoveryDocPath = entry.getKey();
-      new GenClientLibAction().genClientLib(language, outputDirPath, restDiscoveryDocPath,
-          buildSystem);
+      new GenClientLibAction().genClientLib(language, outputDirPath, entry.getValue(), buildSystem);
     }
     return null;
   }


### PR DESCRIPTION
The local discovery refactor broke this command by passing the path to
the discovery doc in, rather than the doc itself. This fixes that and
removes the unnecessary generation of the legacy API config.