### PR TITLE
refactor and cleanup API config validation

### DIFF
--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GenApiConfigAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GenApiConfigAction.java
@@ -18,9 +18,11 @@ package com.google.api.server.spi.tools;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.api.server.spi.ServiceContext;
+import com.google.api.server.spi.TypeLoader;
 import com.google.api.server.spi.config.ApiConfigException;
 import com.google.api.server.spi.config.jsonwriter.JsonConfigWriter;
 import com.google.api.server.spi.config.model.ApiConfig;
+import com.google.api.server.spi.config.model.SchemaRepository;
 import com.google.api.server.spi.config.validation.ApiConfigValidator;
 import com.google.appengine.tools.util.Option;
 import com.google.common.io.Files;
@@ -86,8 +88,10 @@ public class GenApiConfigAction extends EndpointsToolAction {
 
     ClassLoader classLoader = new URLClassLoader(classPath, getClass().getClassLoader());
     ApiConfig.Factory configFactory = new ApiConfig.Factory();
-    ApiConfigValidator validator = new ApiConfigValidator();
-    JsonConfigWriter jsonConfigWriter = new JsonConfigWriter(classLoader, validator);
+    TypeLoader typeLoader = new TypeLoader(classLoader);
+    SchemaRepository schemaRepository = new SchemaRepository(typeLoader);
+    ApiConfigValidator validator = new ApiConfigValidator(typeLoader, schemaRepository);
+    JsonConfigWriter jsonConfigWriter = new JsonConfigWriter(typeLoader, validator);
     ApiConfigGenerator generator =
         new AnnotationApiConfigGenerator(jsonConfigWriter, classLoader, configFactory);
     Map<String, String> apiConfigs = generator.generateConfig(

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/TypeLoader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/TypeLoader.java
@@ -87,6 +87,7 @@ public final class TypeLoader {
     parameterTypes.put(Float.TYPE, "float");
     parameterTypes.put(classLoader.loadClass("java.lang.Double"), "double");
     parameterTypes.put(Double.TYPE, "double");
+    parameterTypes.put(byte[].class, "string");
     /*
      * TODO: Adding support for JSR 310 http://jcp.org/en/jsr/detail?id=310
      * LocalDate --> date, LocalDateTime --> datetime
@@ -96,6 +97,12 @@ public final class TypeLoader {
         classLoader.loadClass("com.google.api.server.spi.types.DateAndTime"), "datetime");
     parameterTypes.put(
         classLoader.loadClass("com.google.api.server.spi.types.SimpleDate"), "date");
+    try {
+      parameterTypes.put(
+          classLoader.loadClass("com.google.appengine.api.datastore.Blob"), "string");
+    } catch (ClassNotFoundException e) {
+      // Do nothing; if we're on Flex, this class won't exist.
+    }
     return Collections.unmodifiableMap(parameterTypes);
   }
 

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/jsonwriter/JsonConfigWriterTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/jsonwriter/JsonConfigWriterTest.java
@@ -345,7 +345,7 @@ public class JsonConfigWriterTest {
     ApiConfigValidator validator = Mockito.mock(ApiConfigValidator.class);
     TypeLoader typeLoader = new TypeLoader();
     JsonConfigWriter writer =
-        new JsonConfigWriter(JsonConfigWriter.class.getClassLoader(), validator);
+        new JsonConfigWriter(new TypeLoader(JsonConfigWriter.class.getClassLoader()), validator);
     ApiConfig oneToday = new ApiConfig.Factory().create(serviceContext, typeLoader, OneToday.class);
     ApiConfig oneTodayAdmin =
         new ApiConfig.Factory().create(serviceContext, typeLoader, OneTodayAdmin.class);
@@ -378,7 +378,7 @@ public class JsonConfigWriterTest {
     ApiConfigValidator validator = Mockito.mock(ApiConfigValidator.class);
     TypeLoader typeLoader = new TypeLoader();
     JsonConfigWriter writer =
-        new JsonConfigWriter(JsonConfigWriter.class.getClassLoader(), validator);
+        new JsonConfigWriter(new TypeLoader(JsonConfigWriter.class.getClassLoader()), validator);
     ApiConfig oneToday = new ApiConfig.Factory().create(serviceContext, typeLoader, OneToday.class);
     ApiConfig oneToday2 =
         new ApiConfig.Factory().create(serviceContext, typeLoader, OneToday2.class);

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/request/ServletRequestParamReaderTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/request/ServletRequestParamReaderTest.java
@@ -97,6 +97,8 @@ public class ServletRequestParamReaderTest {
         .put(TestEndpoint.NAME_LONG_OBJECT, String.valueOf(VALUE_LONG))
         .put(TestEndpoint.NAME_FLOAT_OBJECT, String.valueOf(VALUE_FLOAT))
         .put(TestEndpoint.NAME_DOUBLE_OBJECT, String.valueOf(VALUE_DOUBLE))
+        .put("stringValue", "321")
+        .put("integerValue", "321")
         .put("more", "999").build());
 
     assertEquals(VALUE_STRING, params[0]);
@@ -110,8 +112,8 @@ public class ServletRequestParamReaderTest {
     assertEquals(VALUE_LONG, params[8]);
     assertEquals(VALUE_FLOAT, params[9]);
     assertEquals(VALUE_DOUBLE, params[10]);
-    assertEquals(VALUE_STRING, ((Request) params[11]).getString());
-    assertEquals(VALUE_INTEGER, (int) ((Request) params[11]).getInteger());
+    assertEquals("321", ((Request) params[11]).getStringValue());
+    assertEquals(321, (int) ((Request) params[11]).getIntegerValue());
     assertEquals(USER, params[12]);
     assertEquals(APP_ENGINE_USER, params[13]);
     assertEquals(request, params[14]);
@@ -138,6 +140,7 @@ public class ServletRequestParamReaderTest {
         .put(TestEndpoint.NAME_INTEGER_OBJECT, String.valueOf(VALUE_INTEGER))
         .put(TestEndpoint.NAME_LONG_OBJECT, String.valueOf(VALUE_LONG))
         .put(TestEndpoint.NAME_FLOAT_OBJECT, String.valueOf(VALUE_FLOAT))
+        .put("stringValue", "321")
         .put("more", "999").build());
 
     assertEquals(VALUE_STRING, params[0]);
@@ -151,8 +154,8 @@ public class ServletRequestParamReaderTest {
     assertEquals(VALUE_LONG, params[8]);
     assertEquals(VALUE_FLOAT, params[9]);
     assertNull(params[10]);
-    assertEquals(VALUE_STRING, ((Request) params[11]).getString());
-    assertEquals(-1, (int) ((Request) params[11]).getInteger());
+    assertEquals("321", ((Request) params[11]).getStringValue());
+    assertEquals(-1, (int) ((Request) params[11]).getIntegerValue());
     assertEquals(USER, params[12]);
     assertEquals(APP_ENGINE_USER, params[13]);
     assertEquals(request, params[14]);
@@ -222,20 +225,20 @@ public class ServletRequestParamReaderTest {
   public void testReadByteArrayParameter() throws Exception {
     Method method =
         TestEndpoint.class.getDeclaredMethod("doSomething", byte[].class);
-    Object[] params = readParameters("\"AQIDBA==\"", method);
+    Object[] params = readParameters("{\"bytes\":\"AQIDBA==\"}", method);
 
     assertEquals(1, params.length);
-    assertTrue(Arrays.equals(new byte[]{1, 2, 3, 4}, (byte[]) params[0]));
+    assertThat((byte[]) params[0]).isEqualTo(new byte[]{1, 2, 3, 4});
   }
 
   @Test
   public void testReadBlobParameter() throws Exception {
     Method method =
         TestEndpoint.class.getDeclaredMethod("doBlob", Blob.class);
-    Object[] params = readParameters("\"AQIDBA==\"", method);
+    Object[] params = readParameters("{\"blob\":\"AQIDBA==\"}", method);
 
     assertEquals(1, params.length);
-    assertTrue(Arrays.equals(new byte[]{1, 2, 3, 4}, ((Blob) params[0]).getBytes()));
+    assertThat(((Blob) params[0]).getBytes()).isEqualTo(new byte[]{1, 2, 3, 4});
   }
 
   @Test
@@ -537,7 +540,8 @@ public class ServletRequestParamReaderTest {
     }
     String requestString = "{\"str\":\"hello\",\"" + TestEndpoint.NAME_STRING + "\":\""
         + VALUE_STRING + "\",\"" + TestEndpoint.NAME_INTEGER + "\":" + VALUE_INTEGER
-        + ",\"integer_array\":[1,2,3]," + "\"integer_collection\":[4,5,6]}";
+        + ",\"integer_array\":[1,2,3]," + "\"integer_collection\":[4,5,6], \"stringValue\":"
+        + "\"321\", \"integerValue\":321}";
 
     Method method = TestMultipleResources.class.getDeclaredMethod("foo",
         String.class, Integer[].class, Collection.class, Request.class);
@@ -559,8 +563,8 @@ public class ServletRequestParamReaderTest {
     assertEquals(5, (int) iterator.next());
     assertEquals(6, (int) iterator.next());
     Request request = (Request) params[3];
-    assertEquals(VALUE_STRING, request.getString());
-    assertEquals(VALUE_INTEGER, (int) request.getInteger());
+    assertEquals("321", request.getStringValue());
+    assertEquals(321, (int) request.getIntegerValue());
   }
 
   @Test

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/CollectionContravarianceEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/CollectionContravarianceEndpoint.java
@@ -26,7 +26,7 @@ import javax.inject.Named;
 
 class BaseCollectionContravarianceEndpoint {
   @ApiMethod(name = "api.foos.base", path = "base", httpMethod = HttpMethod.GET)
-  public String foo(List<String> id) {
+  public Foo foo(List<String> id) {
     return null;
   }
 }
@@ -37,7 +37,7 @@ class BaseCollectionContravarianceEndpoint {
 @Api
 public class CollectionContravarianceEndpoint extends BaseCollectionContravarianceEndpoint {
   @ApiMethod(name = "api.foos.fn", path = "fn", httpMethod = HttpMethod.GET)
-  public String foo(@Named("id") Collection<String> id) {
+  public Foo foo(@Named("id") Collection<String> id) {
     return null;
   }
 

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/CollectionCovarianceEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/CollectionCovarianceEndpoint.java
@@ -26,7 +26,7 @@ import javax.inject.Named;
 
 class BaseCollectionCovarianceEndpoint {
   @ApiMethod(name = "api.foos.base", path = "base", httpMethod = HttpMethod.GET)
-  public String foo(Collection<Integer> id) {
+  public Foo foo(Collection<Integer> id) {
     return null;
   }
 }
@@ -37,7 +37,7 @@ class BaseCollectionCovarianceEndpoint {
 @Api
 public class CollectionCovarianceEndpoint extends BaseCollectionCovarianceEndpoint {
   @ApiMethod(name = "api.foos.fn", path = "fn", httpMethod = HttpMethod.GET)
-  public String foo(@Named("id") List<Integer> id) {
+  public Foo foo(@Named("id") List<Integer> id) {
     return null;
   }
 

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/DuplicateMethodEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/DuplicateMethodEndpoint.java
@@ -28,12 +28,12 @@ import javax.inject.Named;
 @Api
 public class DuplicateMethodEndpoint {
   @ApiMethod(name = "api.foos.fn1", path = "fn1", httpMethod = HttpMethod.GET)
-  public String foo(@Named("id") String id) {
+  public Foo foo(@Named("id") String id) {
     return null;
   }
 
   @ApiMethod(name = "api.foos.fn2", path = "fn2", httpMethod = HttpMethod.GET)
-  public String foo(@Named("id") Integer id) {
+  public Foo foo(@Named("id") Integer id) {
     return null;
   }
 }

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/SimpleContravarianceEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/SimpleContravarianceEndpoint.java
@@ -21,7 +21,7 @@ import com.google.api.server.spi.config.ApiMethod.HttpMethod;
 
 class BaseSimpleContravarianceEndpoint {
   @ApiMethod(name = "api.foos.base", path = "base", httpMethod = HttpMethod.GET)
-  public String foo(Number id) {
+  public Foo foo(Number id) {
     return null;
   }
 }
@@ -32,7 +32,7 @@ class BaseSimpleContravarianceEndpoint {
 @Api
 public class SimpleContravarianceEndpoint extends BaseSimpleContravarianceEndpoint {
   @ApiMethod(name = "api.foos.fn", path = "fn", httpMethod = HttpMethod.GET)
-  public String foo(Object id) {
+  public Foo foo(Object id) {
     return null;
   }
 }

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/SimpleCovarianceEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/SimpleCovarianceEndpoint.java
@@ -23,7 +23,7 @@ import javax.inject.Named;
 
 class BaseSimpleCovarianceEndpoint {
   @ApiMethod(name = "api.foos.base", path = "base", httpMethod = HttpMethod.GET)
-  public String foo(Object id) {
+  public Foo foo(Object id) {
     return null;
   }
 }
@@ -34,7 +34,7 @@ class BaseSimpleCovarianceEndpoint {
 @Api
 public class SimpleCovarianceEndpoint extends BaseSimpleCovarianceEndpoint {
   @ApiMethod(name = "api.foos.fn", path = "fn", httpMethod = HttpMethod.GET)
-  public String foo(@Named("id") String id) {
+  public Foo foo(@Named("id") String id) {
     return null;
   }
 }

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/SimpleOverloadEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/SimpleOverloadEndpoint.java
@@ -23,7 +23,7 @@ import javax.inject.Named;
 
 class BaseSimpleOverloadEndpoint {
   @ApiMethod(name = "api.foos.base", path = "base", httpMethod = HttpMethod.GET)
-  public String foo(@Named("id") String id) {
+  public Foo foo(@Named("id") String id) {
     return null;
   }
 }
@@ -34,7 +34,7 @@ class BaseSimpleOverloadEndpoint {
 @Api
 public class SimpleOverloadEndpoint extends BaseSimpleOverloadEndpoint {
   @ApiMethod(name = "api.foos.fn", path = "fn", httpMethod = HttpMethod.GET)
-  public String foo(@Named("id") Integer id) {
+  public Foo foo(@Named("id") Integer id) {
     return null;
   }
 }

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/TestEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/TestEndpoint.java
@@ -36,7 +36,7 @@ import javax.servlet.http.HttpServletRequest;
  * Endpoint class for testing.
  */
 @Api
-public class TestEndpoint extends TestEndpointSuperclass<String> {
+public class TestEndpoint extends TestEndpointSuperclass<Foo> {
 
   public static final String NAME_DATE = "date";
   public static final String NAME_DATE_AND_TIME = "dateandtime";
@@ -52,18 +52,26 @@ public class TestEndpoint extends TestEndpointSuperclass<String> {
   public static final String NAME_FLOAT_OBJECT = "Float";
   public static final String NAME_DOUBLE_OBJECT = "Double";
   public static final String NAME_ENUM = "enum";
-  public static final String RESULT = "result";
+  public static final Foo RESULT = new Foo();
   public static final String ERROR_MESSAGE = "error message";
 
   public static class Request {
     private String string;
-    private final Integer integer = -1;
+    private Integer integer = -1;
 
-    public String getString() {
+    public void setStringValue(String string) {
+      this.string = string;
+    }
+
+    public void setIntegerValue(int integer) {
+      this.integer = integer;
+    }
+
+    public String getStringValue() {
       return string;
     }
 
-    public Integer getInteger() {
+    public Integer getIntegerValue() {
       return integer;
     }
   }
@@ -72,7 +80,7 @@ public class TestEndpoint extends TestEndpointSuperclass<String> {
     TEST1, TEST2
   }
 
-  public String succeed(@Named(NAME_STRING) String s, @Named(NAME_BOOLEAN) boolean b1,
+  public Foo succeed(@Named(NAME_STRING) String s, @Named(NAME_BOOLEAN) boolean b1,
       @Named(NAME_INTEGER) int i1, @Named(NAME_LONG) long l1, @Named(NAME_FLOAT) float f1,
       @Named(NAME_DOUBLE) double d1, @Named(NAME_BOOLEAN_OBJECT) Boolean b2,
       @Named(NAME_INTEGER_OBJECT) Integer i2, @Named(NAME_LONG_OBJECT) Long l2,
@@ -82,46 +90,46 @@ public class TestEndpoint extends TestEndpointSuperclass<String> {
     return RESULT;
   }
 
-  public String getDate(@Named(NAME_DATE) Date date) {
+  public Foo getDate(@Named(NAME_DATE) Date date) {
     return RESULT;
   }
 
   @ApiMethod(path = "dateandtime")
-  public String getDateAndTime(@Named(NAME_DATE_AND_TIME) DateAndTime dateTime) {
+  public Foo getDateAndTime(@Named(NAME_DATE_AND_TIME) DateAndTime dateTime) {
     return RESULT;
   }
 
   @ApiMethod(path = "simpledate")
-  public String getSimpleDate(@Named(NAME_DATE_AND_TIME) SimpleDate simpleDate) {
+  public Foo getSimpleDate(@Named(NAME_DATE_AND_TIME) SimpleDate simpleDate) {
     return RESULT;
   }
 
   @ApiMethod(path = "noresults")
-  public String getResultNoParams() {
+  public Foo getResultNoParams() {
     return RESULT;
   }
 
-  public String fail(@Named(NAME_STRING) String p0, @Named(NAME_INTEGER) int p1, Request request,
+  public Foo fail(@Named(NAME_STRING) String p0, @Named(NAME_INTEGER) int p1, Request request,
       User p2, HttpServletRequest httpRequest) throws BadRequestException {
     throw new BadRequestException(ERROR_MESSAGE);
   }
 
-  public String failOAuth(@Named(NAME_STRING) String p0, @Named(NAME_INTEGER) int p1,
+  public Foo failOAuth(@Named(NAME_STRING) String p0, @Named(NAME_INTEGER) int p1,
       Request request, User p2, HttpServletRequest httpRequest) throws OAuthRequestException {
     throw new OAuthRequestException(ERROR_MESSAGE);
   }
 
-  public String failWrapped() throws Exception {
+  public Foo failWrapped() throws Exception {
     throw new Exception(null, new ServiceException(401, ERROR_MESSAGE));
   }
 
-  public String failIllegalArgumentException() {
+  public Foo failIllegalArgumentException() {
     throw new IllegalArgumentException();
   }
 
-  public void doSomething(byte[] in) {}
+  public void doSomething(@Named("bytes") byte[] in) {}
 
-  public void doBlob(Blob b) {}
+  public void doBlob(@Named("blob") Blob b) {}
 
   public void doParameterizedOverloadTest(Map<String, String> m) {}
 
@@ -130,7 +138,7 @@ public class TestEndpoint extends TestEndpointSuperclass<String> {
   public void doEnum(@Named(NAME_ENUM) TestEnum e) {}
 
   @Override
-  public String overrideMethod(@Named(NAME_STRING) String s) {
+  public Foo overrideMethod(Foo s) {
     return null;
   }
 
@@ -138,8 +146,8 @@ public class TestEndpoint extends TestEndpointSuperclass<String> {
   public void overrideMethod1() {}
 
   @Override
-  public boolean overrideMethod2(@Named(NAME_BOOLEAN) boolean bleh) {
-    return true;
+  public Foo overrideMethod2(@Named(NAME_BOOLEAN) boolean bleh) {
+    return null;
   }
 
   public static Map<String, Object> staticMethod() {

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/TestEndpointSuperclass.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/TestEndpointSuperclass.java
@@ -30,7 +30,7 @@ public class TestEndpointSuperclass<T> {
 
   public void overrideMethod1() {}
 
-  public boolean overrideMethod2(boolean bleh) {
-    return false;
+  public Foo overrideMethod2(boolean bleh) {
+    return null;
   }
 }


### PR DESCRIPTION
This change moves config validation out of JsonConfigWriter into
ApiConfigValidator. JsonConfigWriter is mostly deprecated at this point,
with no need for the older JSON API config with discovery and Swagger
generation being created without it.

* Fixed a potential performance issue in which classes were re-validated
  constantly after each new Endpoint class registration. Now,
  SystemService.Builder triggers a validation of all APIs after class
  registration is finished.
* registerInternalService has been removed. BackendService is the only
  class that utilized this, and it has been removed.
* resolveAndUpdateServiceConfig has been removed. Dynamic datastore
  config reloads are no longer supported.
* Correctly allow byte arrays and datastore Blobs as parameter
  types. Both of these are serialized/deserialized as strings.
* Move checking of return type to ApiConfigValidator.
* Move checking of parameter name/resource field name conflicts to
  ApiConfigValidator.
* Fix a bunch of test cases that had invalid API methods. Most of these
  either had a string return type, which isn't allowed, or a byte array
  or Blob resource, which also isn't allowed.