### PR TITLE
Reenable support for "preferred" flag in the discovery list

### DIFF
--- a/endpoints-framework-tools/src/test/java/com/google/api/server/spi/tools/AnnotationApiConfigGeneratorTest.java
+++ b/endpoints-framework-tools/src/test/java/com/google/api/server/spi/tools/AnnotationApiConfigGeneratorTest.java
@@ -131,7 +131,7 @@ public class AnnotationApiConfigGeneratorTest {
     JsonNode root = objectMapper.readValue(apiConfigSource, JsonNode.class);
 
     verifyApi(root, "thirdParty.api", "https://myapp.appspot.com/_ah/api",
-        "myapi", "v1", "", "https://myapp.appspot.com/_ah/spi", false, false);
+        "myapi", "v1", "", "https://myapp.appspot.com/_ah/spi", false, true);
 
     JsonNode methodGetFoo = root.path("methods").path("myapi.endpoint0.getFoo");
     verifyMethod(methodGetFoo, "foo/{id}", HttpMethod.GET, Endpoint0.class.getName() + ".getFoo",

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiConfig.java
@@ -263,7 +263,7 @@ public class ApiConfig {
     backendRoot =
         serviceContext.getTransferProtocol() + "://" + serviceContext.getAppHostName() + "/_ah/spi";
     isAbstract = false;
-    defaultVersion = false;
+    defaultVersion = true;
     discoverable = true;
     useDatastore = false;
     resource = null;

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiAnnotationConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiAnnotationConfigTest.java
@@ -74,7 +74,7 @@ public class ApiAnnotationConfigTest {
     assertEquals(null, config.getDescription());
     assertEquals("https://appHostName.com/_ah/spi", config.getBackendRoot());
     assertEquals(false, config.getIsAbstract());
-    assertEquals(false, config.getIsDefaultVersion());
+    assertEquals(true, config.getIsDefaultVersion());
     assertEquals(true, config.getIsDiscoverable());
     assertEquals(false, config.getUseDatastore());
   }


### PR DESCRIPTION
The feature of "hiding" some versions of the API explorer is actually quite useful (["Services"](https://developers.google.com/apis-explorer/#p/) vs. ["All versions"](https://developers.google.com/apis-explorer/#s/)). 
Many of our APIs have unstable versions "v1betaN" that we want to make less visible to end users with this feature.

This PR allows to "hide" APIs again, by honoring the "defaultVersion" field on @Api annotations.
But it does not replicate the behavior of the legacy endpoints, that was automatically choosing one version if multiple APIs had the same name (I actually was not able to determine the rule for this).