### PR TITLE
fix discovery and OpenAPI generation

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiMethodConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiMethodConfig.java
@@ -142,6 +142,7 @@ public class ApiMethodConfig {
   private String name;
   private String description;
   private String path;
+  private String canonicalPath;
   private String httpMethod;
 
   // If null, get a default from apiConfig.
@@ -173,6 +174,7 @@ public class ApiMethodConfig {
     this.apiClassConfig = apiClassConfig;
     this.name = original.name;
     this.path = original.path;
+    this.canonicalPath = original.canonicalPath;
     this.description = original.description;
     this.httpMethod = original.httpMethod;
     this.scopeExpression = original.scopeExpression;
@@ -213,8 +215,8 @@ public class ApiMethodConfig {
 
     name = null;
     httpMethod = Preconditions.checkNotNull(restMethod.getHttpMethod(), "httpMethod");
-    path = Preconditions.checkNotNull(
-        resourceTypeName == null ? method.getName() : resourceTypeName.toLowerCase(), "path");
+    setPath(Preconditions.checkNotNull(
+        resourceTypeName == null ? method.getName() : resourceTypeName.toLowerCase(), "path"));
     authLevel = AuthLevel.UNSPECIFIED;
     scopeExpression = null;
     audiences = null;
@@ -371,10 +373,19 @@ public class ApiMethodConfig {
 
   public void setPath(String path) {
     this.path = path;
+    if (path.startsWith("/")) {
+      canonicalPath = path.substring(1);
+    } else {
+      canonicalPath = getApiConfig().getName() + "/" + getApiConfig().getVersion() + "/" + path;
+    }
   }
 
   public String getPath() {
     return path;
+  }
+
+  public String getCanonicalPath() {
+    return canonicalPath;
   }
 
   public void setHttpMethod(String httpMethod) {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
@@ -116,7 +116,7 @@ public class SchemaRepository {
       // If the schema is a placeholder, it's currently being constructed and will be added when
       // the type construction is complete.
       if (schema != PLACEHOLDER_SCHEMA) {
-        schemaByApiKeys.put(key, schema);
+        addSchemaToApi(key, schema);
       }
       return schema;
     }
@@ -166,6 +166,18 @@ public class SchemaRepository {
       typesForConfig.put(type, schema);
       schemaByApiKeys.put(key, schema);
       return schema;
+    }
+  }
+
+  private void addSchemaToApi(ApiKey key, Schema schema) {
+    schemaByApiKeys.put(key, schema);
+    for (Field f : schema.fields().values()) {
+      while (f.type() == FieldType.ARRAY) {
+        f = f.arrayItemSchema();
+      }
+      if (f.type() == FieldType.OBJECT || f.type() == FieldType.ENUM) {
+        addSchemaToApi(key, f.schemaReference().get());
+      }
     }
   }
 

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -453,9 +453,9 @@ public class SwaggerGenerator {
 
   private static SecuritySchemeDefinition toScheme(IssuerConfig issuerConfig) {
     OAuth2Definition tokenDef = new OAuth2Definition().implicit("");
-    tokenDef.setVendorExtension("x-issuer", issuerConfig.getIssuer());
+    tokenDef.setVendorExtension("x-google-issuer", issuerConfig.getIssuer());
     if (!com.google.common.base.Strings.isNullOrEmpty(issuerConfig.getJwksUri())) {
-      tokenDef.setVendorExtension("x-jwks_uri", issuerConfig.getJwksUri());
+      tokenDef.setVendorExtension("x-google-jwks_uri", issuerConfig.getJwksUri());
     }
     return tokenDef;
   }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -222,7 +222,7 @@ public class SwaggerGenerator {
   private void writeApiMethod(ApiMethodConfig methodConfig, EndpointMethod endpointMethod,
       ApiConfig apiConfig, Swagger swagger, SwaggerContext context, boolean writeInternal,
       SchemaRepository repo) throws ApiConfigException {
-    Path path = getOrCreatePath(swagger, apiConfig, methodConfig);
+    Path path = getOrCreatePath(swagger, methodConfig);
     Operation operation = new Operation();
     operation.setOperationId(getOperationId(apiConfig, methodConfig));
     operation.setDescription(methodConfig.getDescription());
@@ -386,9 +386,8 @@ public class SwaggerGenerator {
     throw new IllegalArgumentException("invalid property type");
   }
 
-  private Path getOrCreatePath(Swagger swagger, ApiConfig apiConfig, ApiMethodConfig methodConfig) {
-    String pathStr =
-        "/" + apiConfig.getName() + "/" + apiConfig.getVersion() + "/" + methodConfig.getPath();
+  private Path getOrCreatePath(Swagger swagger, ApiMethodConfig methodConfig) {
+    String pathStr = "/" + methodConfig.getCanonicalPath();
     Path path = swagger.getPath(pathStr);
     if (path == null) {
       path = new Path();

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiMethodConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiMethodConfigTest.java
@@ -44,8 +44,8 @@ import java.util.List;
 public class ApiMethodConfigTest {
   private ApiMethodConfig methodConfig;
 
-  @Mock
-  ApiClassConfig apiClassConfig;
+  @Mock ApiConfig apiConfig;
+  @Mock ApiClassConfig apiClassConfig;
   @Mock EndpointMethod method;
 
   private static final AuthScopeExpression defaultScopeExpression =
@@ -60,12 +60,15 @@ public class ApiMethodConfigTest {
 
   @Before
   public void setUp() throws Exception {
+    Mockito.when(apiConfig.getName()).thenReturn("testapi");
+    Mockito.when(apiConfig.getVersion()).thenReturn("v1");
     Mockito.when(apiClassConfig.getResource()).thenReturn("resource");
     Mockito.when(apiClassConfig.getAuthLevel()).thenReturn(AuthLevel.NONE);
     Mockito.when(apiClassConfig.getScopeExpression()).thenReturn(defaultScopeExpression);
     Mockito.when(apiClassConfig.getAudiences()).thenReturn(defaultAudiences);
     Mockito.when(apiClassConfig.getClientIds()).thenReturn(defaultClientIds);
     Mockito.when(apiClassConfig.getApiClassJavaSimpleName()).thenReturn("className");
+    Mockito.when(apiClassConfig.getApiConfig()).thenReturn(apiConfig);
 
     Mockito.when(method.getMethod()).thenReturn(TestEndpoint.class.getMethod("getResultNoParams"));
     Mockito.doReturn(TestEndpoint.class).when(method).getEndpointClass();

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoveryGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoveryGeneratorTest.java
@@ -25,6 +25,8 @@ import com.google.api.server.spi.config.ApiConfigLoader;
 import com.google.api.server.spi.config.annotationreader.ApiConfigAnnotationReader;
 import com.google.api.server.spi.config.model.ApiConfig;
 import com.google.api.server.spi.discovery.DiscoveryGenerator.DiscoveryContext;
+import com.google.api.server.spi.testing.AbsoluteCommonPathEndpoint;
+import com.google.api.server.spi.testing.AbsolutePathEndpoint;
 import com.google.api.server.spi.testing.ArrayEndpoint;
 import com.google.api.server.spi.testing.EnumEndpoint;
 import com.google.api.server.spi.testing.FooEndpoint;
@@ -129,6 +131,20 @@ public class DiscoveryGeneratorTest {
   public void testWriteDiscovery_PrimitiveEndpoint() throws Exception {
     RestDescription doc = getDiscovery(PrimitiveEndpoint.class, context);
     RestDescription expected = readExpectedAsDiscovery("primitive_endpoint.json");
+    compareDiscovery(expected, doc);
+  }
+
+  @Test
+  public void testWriteDiscovery_AbsolutePathEndpoint() throws Exception {
+    RestDescription doc = getDiscovery(AbsolutePathEndpoint.class, context);
+    RestDescription expected = readExpectedAsDiscovery("absolute_path_endpoint.json");
+    compareDiscovery(expected, doc);
+  }
+
+  @Test
+  public void testWriteDiscovery_AbsoluteCommonPathEndpoint() throws Exception {
+    RestDescription doc = getDiscovery(AbsoluteCommonPathEndpoint.class, context);
+    RestDescription expected = readExpectedAsDiscovery("absolute_common_path_endpoint.json");
     compareDiscovery(expected, doc);
   }
 

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
@@ -30,6 +30,8 @@ import com.google.api.server.spi.config.ApiMethod;
 import com.google.api.server.spi.config.annotationreader.ApiConfigAnnotationReader;
 import com.google.api.server.spi.config.model.ApiConfig;
 import com.google.api.server.spi.swagger.SwaggerGenerator.SwaggerContext;
+import com.google.api.server.spi.testing.AbsoluteCommonPathEndpoint;
+import com.google.api.server.spi.testing.AbsolutePathEndpoint;
 import com.google.api.server.spi.testing.ArrayEndpoint;
 import com.google.api.server.spi.testing.EnumEndpoint;
 import com.google.api.server.spi.testing.FooEndpoint;
@@ -135,6 +137,20 @@ public class SwaggerGeneratorTest {
         configLoader.loadConfiguration(ServiceContext.create(), ApiKeysEndpoint.class);
     Swagger swagger = generator.writeSwagger(ImmutableList.of(config), true, context);
     Swagger expected = readExpectedAsSwagger("api_keys.swagger");
+    compareSwagger(expected, swagger);
+  }
+
+  @Test
+  public void testWriteSwagger_AbsolutePathEndpoint() throws Exception {
+    Swagger swagger = getSwagger(AbsolutePathEndpoint.class, new SwaggerContext(), true);
+    Swagger expected = readExpectedAsSwagger("absolute_path_endpoint.swagger");
+    compareSwagger(expected, swagger);
+  }
+
+  @Test
+  public void testWriteSwagger_AbsoluteCommonPathEndpoint() throws Exception {
+    Swagger swagger = getSwagger(AbsoluteCommonPathEndpoint.class, new SwaggerContext(), true);
+    Swagger expected = readExpectedAsSwagger("absolute_common_path_endpoint.swagger");
     compareSwagger(expected, swagger);
   }
 

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/absolute_common_path_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/absolute_common_path_endpoint.json
@@ -1,0 +1,108 @@
+{
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/userinfo.email": {
+          "description": "View your email address"
+        }
+      }
+    }
+  },
+  "basePath": "/api/absolutepath/v1/",
+  "baseUrl": "https://discovery-test.appspot.com/api/absolutepath/v1/",
+  "batchPath": "batch",
+  "description": "This is an API",
+  "discoveryVersion": "v1",
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  },
+  "id": "absolutepath:v1",
+  "kind": "discovery#restDescription",
+  "methods": {
+    "absolutepath": {
+      "httpMethod": "POST",
+      "id": "absolutepath.absolutepath",
+      "path": "absolutepathmethod",
+      "scopes": [
+        "https://www.googleapis.com/auth/userinfo.email"
+      ]
+    },
+    "create": {
+      "httpMethod": "POST",
+      "id": "absolutepath.create",
+      "path": "create",
+      "response": {
+        "$ref": "Foo"
+      },
+      "scopes": [
+        "https://www.googleapis.com/auth/userinfo.email"
+      ]
+    }
+  },
+  "name": "absolutepath",
+  "parameters": {
+    "alt": {
+      "default": "json",
+      "description": "Data format for the response.",
+      "enum": [
+        "json"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json"
+      ],
+      "location": "query",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query",
+      "type": "string"
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query",
+      "type": "string"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "default": "true",
+      "description": "Returns response with indentations and line breaks.",
+      "location": "query",
+      "type": "boolean"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+      "location": "query",
+      "type": "string"
+    },
+    "userIp": {
+      "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+      "location": "query",
+      "type": "string"
+    }
+  },
+  "protocol": "rest",
+  "rootUrl": "https://discovery-test.appspot.com/api/",
+  "schemas": {
+    "Foo": {
+      "id": "Foo",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "servicePath": "absolutepath/v1/",
+  "version": "v1"
+}

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/absolute_path_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/absolute_path_endpoint.json
@@ -1,0 +1,108 @@
+{
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/userinfo.email": {
+          "description": "View your email address"
+        }
+      }
+    }
+  },
+  "basePath": "/api/",
+  "baseUrl": "https://discovery-test.appspot.com/api/",
+  "batchPath": "batch",
+  "description": "This is an API",
+  "discoveryVersion": "v1",
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  },
+  "id": "absolutepath:v1",
+  "kind": "discovery#restDescription",
+  "methods": {
+    "absolutepath": {
+      "httpMethod": "POST",
+      "id": "absolutepath.absolutepath",
+      "path": "absolutepathmethod",
+      "scopes": [
+        "https://www.googleapis.com/auth/userinfo.email"
+      ]
+    },
+    "create": {
+      "httpMethod": "POST",
+      "id": "absolutepath.create",
+      "path": "absolutepath/v1/create",
+      "response": {
+        "$ref": "Foo"
+      },
+      "scopes": [
+        "https://www.googleapis.com/auth/userinfo.email"
+      ]
+    }
+  },
+  "name": "absolutepath",
+  "parameters": {
+    "alt": {
+      "default": "json",
+      "description": "Data format for the response.",
+      "enum": [
+        "json"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json"
+      ],
+      "location": "query",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query",
+      "type": "string"
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query",
+      "type": "string"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "default": "true",
+      "description": "Returns response with indentations and line breaks.",
+      "location": "query",
+      "type": "boolean"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+      "location": "query",
+      "type": "string"
+    },
+    "userIp": {
+      "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+      "location": "query",
+      "type": "string"
+    }
+  },
+  "protocol": "rest",
+  "rootUrl": "https://discovery-test.appspot.com/api/",
+  "schemas": {
+    "Foo": {
+      "id": "Foo",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "servicePath": "",
+  "version": "v1"
+}

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_common_path_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_common_path_endpoint.swagger
@@ -1,0 +1,58 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "myapi.appspot.com"
+  },
+  "host": "myapi.appspot.com",
+  "basePath": "/_ah/api",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/absolutepath/v1/absolutepathmethod": {
+      "post": {
+        "operationId": "AbsolutepathAbsolutePath",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A successful response"
+          }
+        }
+      }
+    },
+    "/absolutepath/v1/create": {
+      "post": {
+        "operationId": "AbsolutepathCreateFoo",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "schema": {
+              "$ref": "#/definitions/Foo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Foo": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    }
+  }
+}

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
@@ -1,0 +1,58 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "myapi.appspot.com"
+  },
+  "host": "myapi.appspot.com",
+  "basePath": "/_ah/api",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/absolutepath/v1/create": {
+      "post": {
+        "operationId": "AbsolutepathCreateFoo",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "schema": {
+              "$ref": "#/definitions/Foo"
+            }
+          }
+        }
+      }
+    },
+    "/absolutepathmethod": {
+      "post": {
+        "operationId": "AbsolutepathAbsolutePath",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A successful response"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Foo": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    }
+  }
+}

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
@@ -207,15 +207,15 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "https://accounts.google.com",
-      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-issuer": "https://accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     },
     "google_id_token": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "accounts.google.com",
-      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-issuer": "accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     }
   },
   "definitions": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
@@ -207,15 +207,15 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "https://accounts.google.com",
-      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-issuer": "https://accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     },
     "google_id_token": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "accounts.google.com",
-      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-issuer": "accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     }
   },
   "definitions": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
@@ -303,15 +303,15 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "https://accounts.google.com",
-      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-issuer": "https://accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     },
     "google_id_token": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "accounts.google.com",
-      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-issuer": "accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     }
   },
   "definitions": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
@@ -207,15 +207,15 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "https://accounts.google.com",
-      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-issuer": "https://accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     },
     "google_id_token": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "accounts.google.com",
-      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-issuer": "accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     }
   },
   "definitions": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
@@ -97,28 +97,28 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "https://test.auth0.com/authorize",
-      "x-jwks_uri": "https://test.auth0.com/.wellknown/jwks.json"
+      "x-google-issuer": "https://test.auth0.com/authorize",
+      "x-google-jwks_uri": "https://test.auth0.com/.wellknown/jwks.json"
     },
     "nojwks": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "https://nojwks.com"
+      "x-google-issuer": "https://nojwks.com"
     },
     "google_id_token": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "accounts.google.com",
-      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-issuer": "accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     },
     "google_id_token_https": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "https://accounts.google.com",
-      "x-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-issuer": "https://accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
     }
   }
 }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/third_party_auth.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/third_party_auth.swagger
@@ -72,14 +72,14 @@
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "https://test.auth0.com/authorize",
-      "x-jwks_uri": "https://test.auth0.com/.wellknown/jwks.json"
+      "x-google-issuer": "https://test.auth0.com/authorize",
+      "x-google-jwks_uri": "https://test.auth0.com/.wellknown/jwks.json"
     },
     "nojwks": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-issuer": "https://nojwks.com"
+      "x-google-issuer": "https://nojwks.com"
     }
   }
 }

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/AbsoluteCommonPathEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/AbsoluteCommonPathEndpoint.java
@@ -1,0 +1,18 @@
+package com.google.api.server.spi.testing;
+
+import com.google.api.server.spi.config.Api;
+import com.google.api.server.spi.config.ApiMethod;
+
+/**
+ * Testing for API methods that have absolute paths.
+ */
+@Api(name = "absolutepath", version = "v1")
+public class AbsoluteCommonPathEndpoint {
+  @ApiMethod(name = "create", path = "create")
+  public Foo createFoo() {
+    return null;
+  }
+
+  @ApiMethod(name = "absolutepath", path = "/absolutepath/v1/absolutepathmethod")
+  public void absolutePath() { }
+}

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/AbsolutePathEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/AbsolutePathEndpoint.java
@@ -1,0 +1,18 @@
+package com.google.api.server.spi.testing;
+
+import com.google.api.server.spi.config.Api;
+import com.google.api.server.spi.config.ApiMethod;
+
+/**
+ * Testing for API methods that have absolute paths.
+ */
+@Api(name = "absolutepath", version = "v1")
+public class AbsolutePathEndpoint {
+  @ApiMethod(name = "create", path = "create")
+  public Foo createFoo() {
+    return null;
+  }
+
+  @ApiMethod(name = "absolutepath", path = "/absolutepathmethod")
+  public void absolutePath() { }
+}

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/EnumEndpointV2.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/EnumEndpointV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import com.google.api.server.spi.config.Api;
 import com.google.api.server.spi.config.ApiMethod;
 import com.google.api.server.spi.config.Named;
 
-@Api(name = "enum", version = "v1")
-public class EnumEndpoint {
+@Api(name = "enum", version = "v2")
+public class EnumEndpointV2 {
   @ApiMethod(name = "create", path = "{value}")
   public EnumValue create(@Named("value") TestEnum value) {
     return null;

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/EnumValue.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/EnumValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,9 @@
  */
 package com.google.api.server.spi.testing;
 
-import com.google.api.server.spi.config.Api;
-import com.google.api.server.spi.config.ApiMethod;
-import com.google.api.server.spi.config.Named;
-
-@Api(name = "enum", version = "v1")
-public class EnumEndpoint {
-  @ApiMethod(name = "create", path = "{value}")
-  public EnumValue create(@Named("value") TestEnum value) {
-    return null;
-  }
+/**
+ * A resource which wraps a test enum.
+ */
+public class EnumValue {
+  public TestEnum value;
 }


### PR DESCRIPTION
* Methods with absolute paths should now generate the correct discovery output. The common path prefix builder is used to compute the service path and basepath using methods' canonical paths (including API name and version). A method with a path of `/notinanyapipath` will result in a blank service path and a base URL of the Endpoints root path.
* Resources that are shared across multiple APIs now correctly have their field schema added to the API as well.