### PR TITLE
add endpoints-framework-all uberjar artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,9 +97,9 @@ def configureMaven(project, projectName, projectDescription) {
             url 'https://cloud.google.com/endpoints/docs/frameworks/java'
 
             scm {
-              connection 'scm:git:https://github.com/cloudendpoints/endpoints-java-framework'
-              developerConnection 'scm:git:https://github.com/cloudendpoints/endpoints-java-framework'
-              url 'scm:git:https://github.com/cloudendpoints/endpoints-java-framework'
+              connection 'scm:git:https://github.com/cloudendpoints/endpoints-java'
+              developerConnection 'scm:git:https://github.com/cloudendpoints/endpoints-java'
+              url 'scm:git:https://github.com/cloudendpoints/endpoints-java'
             }
 
             licenses {

--- a/endpoints-framework-all/build.gradle
+++ b/endpoints-framework-all/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+  id 'com.github.johnrengelman.shadow' version '1.2.3'
+}
+
+configurations {
+  include
+  compile.extendsFrom include
+}
+
+jar {
+  from {
+    configurations.include.collect { it.isDirectory() ? it : zipTree(it) }
+  }
+}
+
+def repackagedDir = 'endpoints.repackaged'
+
+shadowJar {
+  relocate 'org.apache', "${repackagedDir}.org.apache"
+  relocate 'org.yaml', "${repackagedDir}.org.yaml"
+  relocate 'org.joda', "${repackagedDir}.org.joda"
+  relocate 'com.fasterxml', "${repackagedDir}.com.fasterxml"
+  relocate 'io.swagger', "${repackagedDir}.io.swagger"
+  relocate 'com.google.common', "${repackagedDir}.com.google.common"
+  relocate 'com.google.api.client', "${repackagedDir}.com.google.api.client"
+  relocate 'org.slf4j', "${repackagedDir}.org.slf4j"
+
+  dependencies {
+    exclude(dependency('com.google.appengine:appengine-api-1.0-sdk:.*'))
+    exclude(dependency('javax.servlet:servlet-api:.*'))
+  }
+}
+
+dependencies {
+  include project(':endpoints-framework')
+  compile group: 'com.google.appengine', name: 'appengine-api-1.0-sdk', version: appengineVersion
+  compile group: 'javax.servlet', name: 'servlet-api', version: servletVersion
+}
+
+configureMaven(project, 'Endpoints Framework', 'A framework for building RESTful web APIs.')

--- a/endpoints-framework-guice/build.gradle
+++ b/endpoints-framework-guice/build.gradle
@@ -20,7 +20,7 @@ configureMaven(
     'Extension to configure the Endpoints Framework via Guice.')
 
 dependencies {
-  compile project(':endpoints-framework')
+  compileOnly project(':endpoints-framework')
   compile group: 'com.google.inject', name: 'guice', version: guiceVersion
   compile group: 'com.google.inject.extensions', name: 'guice-servlet', version: guiceVersion
 

--- a/endpoints-framework-guice/src/main/java/com/google/api/server/spi/guice/Preconditions.java
+++ b/endpoints-framework-guice/src/main/java/com/google/api/server/spi/guice/Preconditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2017 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,15 @@
  */
 package com.google.api.server.spi.guice;
 
-import com.google.api.server.spi.EndpointsServlet;
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
-
 /**
- * A subclass of {@link EndpointsServlet} which facilitates Guice injection.
+ * Rather than shading all of Guava into an endpoints-framework-guice-all artifact, we include the
+ * necessary functionality in this small helper class to remove the dependency.
  */
-@Singleton
-public class GuiceEndpointsServlet extends EndpointsServlet {
-  private final ServiceMap services;
-
-  @Inject
-  public GuiceEndpointsServlet(ServiceMap services) {
-    this.services = Preconditions.checkNotNull(services, "services");
-  }
-
-  @Override
-  protected <T> T createService(Class<T> serviceClass) {
-    return services.get(serviceClass);
+final class Preconditions {
+  static <T> T checkNotNull(T ref, String errorMessage) {
+    if (ref == null) {
+      throw new NullPointerException(errorMessage);
+    }
+    return ref;
   }
 }

--- a/endpoints-framework-guice/src/main/java/com/google/api/server/spi/guice/ServiceMap.java
+++ b/endpoints-framework-guice/src/main/java/com/google/api/server/spi/guice/ServiceMap.java
@@ -15,7 +15,6 @@
  */
 package com.google.api.server.spi.guice;
 
-import com.google.common.base.Preconditions;
 import com.google.inject.Binder;
 
 import java.util.ArrayList;

--- a/endpoints-framework/build.gradle
+++ b/endpoints-framework/build.gradle
@@ -113,3 +113,4 @@ dependencies {
   testCompile group: 'org.springframework', name: 'spring-test', version: springtestVersion
   testCompile group: 'com.google.guava', name: 'guava-testlib', version: guavaVersion
 }
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':endpoints-framework', ':endpoints-framework-tools', ':endpoints-framework-guice', ':test-utils', ':discovery-client', ':test-compat', ':test-compat:legacy-app', ':test-compat:new-app', ':test-compat:new-app-guice'
+include ':endpoints-framework', 'endpoints-framework-all', ':endpoints-framework-tools', ':endpoints-framework-guice', ':test-utils', ':discovery-client', ':test-compat', ':test-compat:legacy-app', ':test-compat:new-app', ':test-compat:new-app-guice'


### PR DESCRIPTION
* endpoints-framework-all now has all transitive dependencies included
  in its JAR, repackaged to avoid dependency conflicts
* endpoints-framework-guice no longer has endpoints-framework as a
  dependency, so that one can use the artifact with endpoints-framework
  or endpoints-framework-all.
* endpoints-framework-guice has a small Preconditions class now so that
  it doesn't have to depend on Guava, which it previously was
  transitively.
* POM URLs have been fixed to be the correct address.