### PR TITLE
fix NPE caused by missing credentials

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/ServletRequestParamReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/ServletRequestParamReader.java
@@ -134,7 +134,7 @@ public class ServletRequestParamReader extends AbstractParamReader {
       if (User.class.isAssignableFrom(clazz)) {
         // User type parameter requires no Named annotation (ignored if present)
         User user = getUser();
-        if (clazz.isAssignableFrom(user.getClass())) {
+        if (user == null || clazz.isAssignableFrom(user.getClass())) {
           params[i] = user;
           logger.log(Level.FINE, "deserialize: User injected into param[{0}]", i);
         } else {


### PR DESCRIPTION
This case was broken by the refactoring to allow User subclass
injection, since it checks the User object's class for
assignability. This check is now skipped if the value is null.