### PR TITLE
fix shadow JAR distribution

### DIFF
--- a/endpoints-framework-all/build.gradle
+++ b/endpoints-framework-all/build.gradle
@@ -16,6 +16,7 @@ jar {
 def repackagedDir = 'endpoints.repackaged'
 
 shadowJar {
+  classifier = null
   relocate 'org.apache', "${repackagedDir}.org.apache"
   relocate 'org.yaml', "${repackagedDir}.org.yaml"
   relocate 'org.joda', "${repackagedDir}.org.joda"
@@ -29,6 +30,10 @@ shadowJar {
     exclude(dependency('com.google.appengine:appengine-api-1.0-sdk:.*'))
     exclude(dependency('javax.servlet:servlet-api:.*'))
   }
+}
+
+artifacts {
+  archives shadowJar
 }
 
 dependencies {


### PR DESCRIPTION
Currently, dependencies are repackaged in the JAR, but the framework
classes aren't rewritten. This fixes the problem.