### PR TITLE
allow Authenticators to throw ServiceException

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/Authenticator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/Authenticator.java
@@ -15,6 +15,7 @@
  */
 package com.google.api.server.spi.config;
 
+import com.google.api.server.spi.ServiceException;
 import com.google.api.server.spi.auth.common.User;
 
 import javax.servlet.http.HttpServletRequest;
@@ -35,5 +36,5 @@ public interface Authenticator {
    *
    * @return The authenticated user or null if there is no auth or auth has failed.
    */
-  User authenticate(HttpServletRequest request);
+  User authenticate(HttpServletRequest request) throws ServiceException;
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/Auth.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/Auth.java
@@ -16,6 +16,7 @@
 package com.google.api.server.spi.request;
 
 import com.google.api.server.spi.EnvUtil;
+import com.google.api.server.spi.ServiceException;
 import com.google.api.server.spi.auth.EndpointsAuthenticator;
 import com.google.api.server.spi.auth.common.User;
 import com.google.api.server.spi.config.Authenticator;
@@ -92,7 +93,7 @@ public class Auth {
   /**
    * Authenticate the request and retrieve a {@code User}. Should only run once per request.
    */
-  User authenticate() {
+  User authenticate() throws ServiceException {
     Iterable<Authenticator> authenticators = getAuthenticatorInstances();
     User user = null;
     if (authenticators != null) {
@@ -110,7 +111,7 @@ public class Auth {
    * Authenticate the request and retrieve an {@code com.google.appengine.api.users.User}. Should
    * only run once per request.
    */
-  com.google.appengine.api.users.User authenticateAppEngineUser() {
+  com.google.appengine.api.users.User authenticateAppEngineUser() throws ServiceException {
     if (!EnvUtil.isRunningOnAppEngine()) {
       return null;
     }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/ParamReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/ParamReader.java
@@ -15,7 +15,7 @@
  */
 package com.google.api.server.spi.request;
 
-import com.google.api.server.spi.response.BadRequestException;
+import com.google.api.server.spi.ServiceException;
 
 /**
  * Reads a request and returns an array of parameter values.
@@ -24,8 +24,8 @@ public interface ParamReader {
 
   /**
    * Reads parameters in JSON into an Object array to be used to invoke an Endpoint method.
-   * @throws BadRequestException when reading of input stream failed, input JSON is invalid,
-   * or cannot be mapped into parameter objects.
+   * @throws ServiceException when reading of input stream failed, input JSON is invalid,
+   * or cannot be mapped into parameter objects, or user authentication fails.
    */
-  Object[] read() throws BadRequestException;
+  Object[] read() throws ServiceException;
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/RestServletRequestParamReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/RestServletRequestParamReader.java
@@ -17,6 +17,7 @@ package com.google.api.server.spi.request;
 
 import com.google.api.server.spi.EndpointMethod;
 import com.google.api.server.spi.IoUtil;
+import com.google.api.server.spi.ServiceException;
 import com.google.api.server.spi.Strings;
 import com.google.api.server.spi.config.model.ApiMethodConfig;
 import com.google.api.server.spi.config.model.ApiParameterConfig;
@@ -69,7 +70,7 @@ public class RestServletRequestParamReader extends ServletRequestParamReader {
   }
 
   @Override
-  public Object[] read() throws BadRequestException {
+  public Object[] read() throws ServiceException {
     // Assumes input stream to be encoded in UTF-8
     // TODO: Take charset from content-type as encoding
     try {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/ServletRequestParamReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/ServletRequestParamReader.java
@@ -18,6 +18,7 @@ package com.google.api.server.spi.request;
 import com.google.api.server.spi.ConfiguredObjectMapper;
 import com.google.api.server.spi.EndpointMethod;
 import com.google.api.server.spi.IoUtil;
+import com.google.api.server.spi.ServiceException;
 import com.google.api.server.spi.auth.common.User;
 import com.google.api.server.spi.config.Named;
 import com.google.api.server.spi.config.annotationreader.AnnotationUtil;
@@ -122,7 +123,7 @@ public class ServletRequestParamReader extends AbstractParamReader {
   }
 
   protected Object[] deserializeParams(JsonNode node) throws IOException, IllegalAccessException,
-      InvocationTargetException, NoSuchMethodException {
+      InvocationTargetException, NoSuchMethodException, ServiceException {
     EndpointMethod method = getMethod();
     Class<?>[] paramClasses = method.getParameterClasses();
     TypeToken<?>[] paramTypes = method.getParameterTypes();
@@ -187,12 +188,12 @@ public class ServletRequestParamReader extends AbstractParamReader {
   }
 
   @VisibleForTesting
-  User getUser() {
+  User getUser() throws ServiceException {
     return Auth.from(servletRequest).authenticate();
   }
 
   @VisibleForTesting
-  com.google.appengine.api.users.User getAppEngineUser() {
+  com.google.appengine.api.users.User getAppEngineUser() throws ServiceException {
     return Auth.from(servletRequest).authenticateAppEngineUser();
   }
 
@@ -297,7 +298,7 @@ public class ServletRequestParamReader extends AbstractParamReader {
   }
 
   @Override
-  public Object[] read() throws BadRequestException {
+  public Object[] read() throws ServiceException {
     // Assumes input stream to be encoded in UTF-8
     // TODO: Take charset from content-type as encoding
     try {


### PR DESCRIPTION
This feature request lets Authenticators throw ServiceExcpetions, which
are then written in the standard JSON format. This change also refactors
exception handling when calling an API method to clean up the logic a
bit, and change the logging level so that 5xx-level ServiceExceptions
log at the WARNING level, and others at INFO.