### PR TITLE
strip redundant port numbers to fix API Explorer

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/ExplorerHandler.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/ExplorerHandler.java
@@ -35,7 +35,7 @@ public class ExplorerHandler implements DispatcherHandler<EndpointsContext> {
   }
 
   private String getExplorerUrl(HttpServletRequest req, String path) {
-    String url = Strings.stripTrailingSlash(req.getRequestURL().toString());
+    String url = stripRedundantPorts(Strings.stripTrailingSlash(req.getRequestURL().toString()));
     // This will convert http://localhost:8080/_ah/api/explorer to
     // http://apis-explorer.appspot.com/apis-explorer/?base=http://localhost:8080/_ah/api&
     //   root=http://localhost:8080/_ah/api
@@ -44,5 +44,16 @@ public class ExplorerHandler implements DispatcherHandler<EndpointsContext> {
     // by default.
     String apiRoot = url.substring(0, url.length() - path.length() - 1);
     return EXPLORER_URL + "?base=" + apiRoot + "&root=" + apiRoot;
+  }
+
+  private static String stripRedundantPorts(String url) {
+    if (url == null) {
+      return null;
+    } else if (url.startsWith("http:") && url.contains(":80/")) {
+      return url.replace(":80/", "/");
+    } else if (url.startsWith("https:") && url.contains(":443/")) {
+      return url.replace(":443/", "/");
+    }
+    return url;
   }
 }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/handlers/ExplorerHandlerTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/handlers/ExplorerHandlerTest.java
@@ -31,9 +31,27 @@ import javax.servlet.http.HttpServletResponse;
 public class ExplorerHandlerTest {
   @Test
   public void testHandle() throws Exception {
+    testHandle("http", 8080, "http://apis-explorer.appspot.com/apis-explorer/"
+        + "?base=http://localhost:8080/_ah/api&root=http://localhost:8080/_ah/api");
+  }
+
+  @Test
+  public void testHandle_explicitHttpPort() throws Exception {
+    testHandle("http", 80, "http://apis-explorer.appspot.com/apis-explorer/"
+        + "?base=http://localhost/_ah/api&root=http://localhost/_ah/api");
+  }
+
+  @Test
+  public void testHandle_explicitHttpsPort() throws Exception {
+    testHandle("https", 443, "http://apis-explorer.appspot.com/apis-explorer/"
+        + "?base=https://localhost/_ah/api&root=https://localhost/_ah/api");
+  }
+
+  private void testHandle(String scheme, int port, String expectedLocation) throws Exception {
     MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setScheme(scheme);
     request.setServerName("localhost");
-    request.setServerPort(8080);
+    request.setServerPort(port);
     request.setRequestURI("/_ah/api/explorer/");
     MockHttpServletResponse response = new MockHttpServletResponse();
     ExplorerHandler handler = new ExplorerHandler();
@@ -41,8 +59,6 @@ public class ExplorerHandlerTest {
     handler.handle(context);
 
     assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FOUND);
-    assertThat(response.getHeader("Location")).isEqualTo(
-        "http://apis-explorer.appspot.com/apis-explorer/?base=http://localhost:8080/_ah/api"
-            + "&root=http://localhost:8080/_ah/api");
+    assertThat(response.getHeader("Location")).isEqualTo(expectedLocation);
   }
 }


### PR DESCRIPTION
API Explorer does not allow http://host:80 or https://host:443, which is
what we get from the servlet container. This change removes the port
numbers in these cases.