### PR TITLE
fix stack overflow issue with recursive schema

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
@@ -170,6 +170,9 @@ public class SchemaRepository {
   }
 
   private void addSchemaToApi(ApiKey key, Schema schema) {
+    if (schemaByApiKeys.containsEntry(key, schema)) {
+      return;
+    }
     schemaByApiKeys.put(key, schema);
     for (Field f : schema.fields().values()) {
       while (f.type() == FieldType.ARRAY) {


### PR DESCRIPTION
Currently, if you add a self-referencing type to multiple APIs, a
StackOverflowError will occur. This change fixes that by not attempting
to add a type to an API that's already added.