### PR TITLE
fix empty servicePath in discovery

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/ObjectMapperUtil.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/ObjectMapperUtil.java
@@ -18,7 +18,6 @@ package com.google.api.server.spi;
 import com.google.api.server.spi.config.annotationreader.ApiAnnotationIntrospector;
 import com.google.api.server.spi.config.model.ApiSerializationConfig;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
@@ -107,10 +106,9 @@ public class ObjectMapperUtil {
     public JsonSerializer<?> modifyMapSerializer(SerializationConfig config, MapType valueType,
         BeanDescription beanDesc, JsonSerializer<?> serializer) {
       if (serializer instanceof MapSerializer) {
-        // For some reason, NON_EMPTY is not being propagated to MapSerializer, so we replace it
-        // with one that has it set.
-        return new DeepEmptyCheckingSerializer<>(
-            ((MapSerializer) serializer).withContentInclusion(JsonInclude.Include.NON_EMPTY));
+        // TODO: We should probably be propagating the NON_EMPTY inclusion here, but it's breaking
+        // discovery.
+        return new DeepEmptyCheckingSerializer<>(serializer);
       }
       return serializer;
     }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoveryGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoveryGeneratorTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.server.spi.IoUtil;
+import com.google.api.server.spi.ObjectMapperUtil;
 import com.google.api.server.spi.ServiceContext;
 import com.google.api.server.spi.TypeLoader;
 import com.google.api.server.spi.config.ApiConfigLoader;
@@ -47,8 +48,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import io.swagger.util.Json;
-
 /**
  * Tests for {@link DiscoveryGenerator}.
  */
@@ -56,7 +55,7 @@ import io.swagger.util.Json;
 public class DiscoveryGeneratorTest {
   private final DiscoveryContext context = new DiscoveryContext()
       .setApiRoot("https://discovery-test.appspot.com/api");
-  private final ObjectMapper mapper = Json.mapper();
+  private final ObjectMapper mapper = ObjectMapperUtil.createStandardObjectMapper();
   private DiscoveryGenerator generator;
   private ApiConfigLoader configLoader;
   private SchemaRepository schemaRepository;

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/absolute_path_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/absolute_path_endpoint.json
@@ -23,7 +23,15 @@
     "absolutepath": {
       "httpMethod": "POST",
       "id": "absolutepath.absolutepath",
-      "path": "absolutepathmethod",
+      "path": "absolutepathmethod/v1",
+      "scopes": [
+        "https://www.googleapis.com/auth/userinfo.email"
+      ]
+    },
+    "absolutepath2": {
+      "httpMethod": "POST",
+      "id": "absolutepath.absolutepath2",
+      "path": "absolutepathmethod2/v1",
       "scopes": [
         "https://www.googleapis.com/auth/userinfo.email"
       ]

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
@@ -30,9 +30,20 @@
         }
       }
     },
-    "/absolutepathmethod": {
+    "/absolutepathmethod/v1": {
       "post": {
         "operationId": "AbsolutepathAbsolutePath",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A successful response"
+          }
+        }
+      }
+    },
+    "/absolutepathmethod2/v1": {
+      "post": {
+        "operationId": "AbsolutepathAbsolutePath2",
         "parameters": [],
         "responses": {
           "200": {

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/AbsolutePathEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/AbsolutePathEndpoint.java
@@ -13,6 +13,9 @@ public class AbsolutePathEndpoint {
     return null;
   }
 
-  @ApiMethod(name = "absolutepath", path = "/absolutepathmethod")
+  @ApiMethod(name = "absolutepath", path = "/absolutepathmethod/v1")
   public void absolutePath() { }
+
+  @ApiMethod(name = "absolutepath2", path = "/absolutepathmethod2/v1")
+  public void absolutePath2() { }
 }


### PR DESCRIPTION
The discovery test was not catching this issue in part because it wasn't
using the exact same JSON serialization as it does at runtime. That has
also been fixed. This change will likely reintroduce empty maps in
serialization, but this is currently the best workaround to allow empty
strings inside maps, which we need to serialize the discovery document
correctly.