### PR TITLE
Set CORS-related headers before writing body for flex env support

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/EndpointsMethodHandler.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/handlers/EndpointsMethodHandler.java
@@ -111,12 +111,12 @@ public class EndpointsMethodHandler {
             serviceName);
         ParamReader reader = createRestParamReader(context, serializationConfig);
         ResultWriter writer = createResultWriter(context, serializationConfig);
-        systemService.invokeServiceMethod(service, endpointMethod.getMethod(), reader, writer);
         if (request.getHeader(Headers.ORIGIN) != null) {
           HttpServletResponse response = context.getResponse();
           CorsHandler.allowOrigin(request, response);
           CorsHandler.setAccessControlAllowCredentials(response);
         }
+        systemService.invokeServiceMethod(service, endpointMethod.getMethod(), reader, writer);
       } catch (Exception e) {
         // All exceptions here are unexpected, including the ServiceException that may be thrown by
         // the findService call. We return an internal server error and leave the details in the


### PR DESCRIPTION
On flex env, it seems like custom headers set on the response after writing to the body are not always being written to the final http response.
This causes CORS support not to work with Cloud Endpints v2 on flex env (it works fine on AppEngine standard though).

Simply changing the code to write CORS headers before the response body fixes the issue.
Additionally, it makes any backend error that would happen available to CORS clients as well.
