### PR TITLE
use hostname and path flags in all of the CLI

### DIFF
--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/EndpointsToolAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/EndpointsToolAction.java
@@ -326,8 +326,7 @@ public abstract class EndpointsToolAction extends Action {
         OPTION_HOSTNAME_SHORT,
         OPTION_HOSTNAME_LONG,
         "HOSTNAME",
-        "Sets the hostname for the generated OpenAPI document. Default is the app's default "
-            + "hostname.");
+        "Sets the hostname for the generated document. Default is the app's default hostname.");
   }
 
   protected Option makeBasePathOption() {
@@ -335,8 +334,7 @@ public abstract class EndpointsToolAction extends Action {
         OPTION_BASE_PATH_SHORT,
         OPTION_BASE_PATH_LONG,
         "BASE_PATH",
-        "Sets the base path for the generated OpenAPI document. Default is " + DEFAULT_BASE_PATH
-            + ".");
+        "Sets the base path for the generated document. Default is " + DEFAULT_BASE_PATH + ".");
   }
 
   /**

--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetClientLibAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetClientLibAction.java
@@ -33,21 +33,18 @@ public class GetClientLibAction extends EndpointsToolAction {
   public static final String NAME = "get-client-lib";
 
   private Option classPathOption = makeClassPathOption();
-
   private Option languageOption = makeLanguageOption();
-
   private Option outputOption = makeOutputOption();
-
   private Option warOption = makeWarOption();
-
   private Option buildSystemOption = makeBuildSystemOption();
-
   private Option debugOption = makeDebugOption();
+  private Option hostnameOption = makeHostnameOption();
+  private Option basePathOption = makeBasePathOption();
 
   public GetClientLibAction() {
     super(NAME);
     setOptions(Arrays.asList(classPathOption, languageOption, outputOption, warOption,
-        buildSystemOption, debugOption));
+        buildSystemOption, debugOption, hostnameOption, basePathOption));
     setShortDescription("Generates a client library");
     setExampleString("<Endpoints tool> get-client-lib --language=java --build_system=maven "
         + "com.google.devrel.samples.ttt.spi.BoardV1 com.google.devrel.samples.ttt.spi.ScoresV1");
@@ -62,8 +59,10 @@ public class GetClientLibAction extends EndpointsToolAction {
       return false;
     }
     getClientLib(computeClassPath(warPath, getClassPath(classPathOption)),
-        getLanguage(languageOption), getOutputPath(outputOption), warPath, serviceClassNames,
-        getBuildSystem(buildSystemOption), getDebug(debugOption));
+        getLanguage(languageOption), getOutputPath(outputOption), serviceClassNames,
+        getBuildSystem(buildSystemOption), getHostname(hostnameOption, warPath),
+        getBasePath(basePathOption), getDebug(debugOption)
+    );
     return true;
   }
 
@@ -73,16 +72,17 @@ public class GetClientLibAction extends EndpointsToolAction {
    * @param classPath Class path to load service classes and their dependencies
    * @param language Language of the client library.  Only "java" is supported right now
    * @param outputDirPath Directory to write output files into
-   * @param warPath Directory or file containing a WAR layout
    * @param serviceClassNames Array of service class names of the API
    * @param buildSystem The build system to use for the client library
+   * @param hostname The hostname to use
+   * @param basePath The base path to use
    * @param debug Whether or not to output intermediate output files
    */
   public Object getClientLib(URL[] classPath, String language, String outputDirPath,
-      String warPath, List<String> serviceClassNames, String buildSystem, boolean debug)
-          throws ClassNotFoundException, IOException, ApiConfigException {
+      List<String> serviceClassNames, String buildSystem, String hostname, String basePath,
+      boolean debug) throws ClassNotFoundException, IOException, ApiConfigException {
     Map<String, String> discoveryDocs = new GetDiscoveryDocAction().getDiscoveryDoc(
-        classPath, outputDirPath, warPath, serviceClassNames, debug, false /* outputToDisk */);
+        classPath, outputDirPath, serviceClassNames, basePath, hostname, debug /* outputToDisk */);
     for (Map.Entry<String, String> entry : discoveryDocs.entrySet()) {
       new GenClientLibAction().genClientLib(language, outputDirPath, entry.getValue(), buildSystem);
     }

--- a/endpoints-framework-tools/src/test/java/com/google/api/server/spi/tools/GetClientLibActionTest.java
+++ b/endpoints-framework-tools/src/test/java/com/google/api/server/spi/tools/GetClientLibActionTest.java
@@ -42,10 +42,11 @@ public class GetClientLibActionTest extends EndpointsToolTest {
   private URL[] classPath;
   private String language;
   private String outputDirPath;
-  private String warPath;
   private List<String> serviceClassNames;
   private String buildSystem;
   private boolean debugOutput;
+  private String hostname;
+  private String basePath;
   private GetClientLibAction testAction;
 
   @Override
@@ -61,19 +62,21 @@ public class GetClientLibActionTest extends EndpointsToolTest {
     classPath = null;
     language = null;
     outputDirPath = null;
-    warPath = null;
     serviceClassNames = null;
+    hostname = null;
+    basePath = null;
     testAction = new GetClientLibAction() {
 
       @Override
       public Object getClientLib(
-          URL[] c, String l, String o, String w, List<String> s, String b, boolean d) {
+          URL[] c, String l, String o, List<String> s, String bs, String h, String bp, boolean d) {
         classPath = c;
         language = l;
         outputDirPath = o;
-        warPath = w;
         serviceClassNames = s;
-        buildSystem = b;
+        buildSystem = bs;
+        hostname = h;
+        basePath = bp;
         debugOutput = d;
         return null;
       }
@@ -82,8 +85,9 @@ public class GetClientLibActionTest extends EndpointsToolTest {
 
   @Test
   public void testMissingOption() throws Exception {
-    tool.execute(new String[]{
-        GetClientLibAction.NAME, option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT), "classPath",
+    tool.execute(new String[]{GetClientLibAction.NAME,
+        option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT), "classPath",
+        option(EndpointsToolAction.OPTION_HOSTNAME_SHORT), "foo.com",
         "MyService"});
     assertFalse(usagePrinted);
     assertThat(Lists.newArrayList(classPath))
@@ -94,7 +98,6 @@ public class GetClientLibActionTest extends EndpointsToolTest {
                 .toURL());
     assertEquals(EndpointsToolAction.DEFAULT_LANGUAGE, language);
     assertEquals(EndpointsToolAction.DEFAULT_OUTPUT_PATH, outputDirPath);
-    assertEquals(EndpointsToolAction.DEFAULT_WAR_PATH, warPath);
     assertStringsEqual(Arrays.asList("MyService"), serviceClassNames);
   }
 
@@ -108,10 +111,11 @@ public class GetClientLibActionTest extends EndpointsToolTest {
 
   @Test
   public void testGetClientLib() throws Exception {
-    tool.execute(
-        new String[]{GetClientLibAction.NAME, option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT),
-        "classPath", option(EndpointsToolAction.OPTION_LANGUAGE_SHORT), "java",
+    tool.execute(new String[]{GetClientLibAction.NAME,
+        option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT), "classPath",
+        option(EndpointsToolAction.OPTION_LANGUAGE_SHORT), "java",
         option(EndpointsToolAction.OPTION_OUTPUT_DIR_SHORT), "outputDir",
+        option(EndpointsToolAction.OPTION_HOSTNAME_SHORT), "foo.com",
         "MyService", "MyService2"});
     assertFalse(usagePrinted);
     assertThat(Lists.newArrayList(classPath))
@@ -122,19 +126,20 @@ public class GetClientLibActionTest extends EndpointsToolTest {
                 .toURL());
     assertEquals("java", language);
     assertEquals("outputDir", outputDirPath);
-    assertEquals(EndpointsToolAction.DEFAULT_WAR_PATH, warPath);
     assertStringsEqual(Arrays.asList("MyService", "MyService2"), serviceClassNames);
     assertEquals(null, buildSystem);
     assertFalse(debugOutput);
+    assertThat(basePath).isEqualTo("/_ah/api");
   }
 
   @Test
   public void testGetClientLibWithBuildSystem() throws Exception {
-    tool.execute(
-        new String[]{GetClientLibAction.NAME, option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT),
-        "classPath", option(EndpointsToolAction.OPTION_LANGUAGE_SHORT), "java",
+    tool.execute(new String[]{GetClientLibAction.NAME,
+        option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT), "classPath",
+        option(EndpointsToolAction.OPTION_LANGUAGE_SHORT), "java",
         option(EndpointsToolAction.OPTION_OUTPUT_DIR_SHORT), "outputDir",
         option(EndpointsToolAction.OPTION_BUILD_SYSTEM_SHORT), "maven",
+        option(EndpointsToolAction.OPTION_HOSTNAME_SHORT), "foo.com",
         "MyService", "MyService2"});
     assertFalse(usagePrinted);
     assertThat(Lists.newArrayList(classPath))
@@ -145,7 +150,6 @@ public class GetClientLibActionTest extends EndpointsToolTest {
                 .toURL());
     assertEquals("java", language);
     assertEquals("outputDir", outputDirPath);
-    assertEquals(EndpointsToolAction.DEFAULT_WAR_PATH, warPath);
     assertStringsEqual(Arrays.asList("MyService", "MyService2"), serviceClassNames);
     assertEquals("maven", buildSystem);
     assertFalse(debugOutput);
@@ -153,11 +157,14 @@ public class GetClientLibActionTest extends EndpointsToolTest {
 
   @Test
   public void testGetClientLibWithDebugOutput() throws Exception {
-    tool.execute(
-        new String[]{GetClientLibAction.NAME, option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT),
-        "classPath", option(EndpointsToolAction.OPTION_LANGUAGE_SHORT), "java",
+    tool.execute(new String[]{GetClientLibAction.NAME,
+        option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT), "classPath",
+        option(EndpointsToolAction.OPTION_LANGUAGE_SHORT), "java",
         option(EndpointsToolAction.OPTION_OUTPUT_DIR_SHORT), "outputDir",
-        option(EndpointsToolAction.OPTION_DEBUG, false), "MyService", "MyService2"});
+        option(EndpointsToolAction.OPTION_DEBUG, false),
+        option(EndpointsToolAction.OPTION_HOSTNAME_SHORT), "foo.com",
+        option(EndpointsToolAction.OPTION_BASE_PATH_SHORT), "/api",
+        "MyService", "MyService2"});
     assertFalse(usagePrinted);
     assertThat(Lists.newArrayList(classPath))
         .containsExactly(new File("classPath").toURI().toURL(),
@@ -167,9 +174,10 @@ public class GetClientLibActionTest extends EndpointsToolTest {
                 .toURL());
     assertEquals("java", language);
     assertEquals("outputDir", outputDirPath);
-    assertEquals(EndpointsToolAction.DEFAULT_WAR_PATH, warPath);
     assertStringsEqual(Arrays.asList("MyService", "MyService2"), serviceClassNames);
     assertEquals(null, buildSystem);
     assertTrue(debugOutput);
+    assertThat(hostname).isEqualTo("foo.com");
+    assertThat(basePath).isEqualTo("/api");
   }
 }

--- a/endpoints-framework-tools/src/test/java/com/google/api/server/spi/tools/GetDiscoveryDocActionTest.java
+++ b/endpoints-framework-tools/src/test/java/com/google/api/server/spi/tools/GetDiscoveryDocActionTest.java
@@ -41,10 +41,11 @@ public class GetDiscoveryDocActionTest extends EndpointsToolTest {
 
   private URL[] classPath;
   private String outputDirPath;
-  private String warPath;
   private List<String> serviceClassNames;
   private GetDiscoveryDocAction testAction;
-  private boolean debugOutput;
+  private String hostname;
+  private String basePath;
+  private boolean outputToDisk;
 
   @Override
   protected void addTestAction(Map<String, EndpointsToolAction> commands) {
@@ -58,18 +59,20 @@ public class GetDiscoveryDocActionTest extends EndpointsToolTest {
     usagePrinted = false;
     classPath = null;
     outputDirPath = null;
-    warPath = null;
     serviceClassNames = null;
+    hostname = null;
+    basePath = null;
     testAction = new GetDiscoveryDocAction() {
 
       @Override
       public Map<String, String> getDiscoveryDoc(
-          URL[] c, String o, String w, List<String> s, boolean d) {
+          URL[] c, String o, List<String> s, String h, String b, boolean d) {
         classPath = c;
         outputDirPath = o;
-        warPath = w;
         serviceClassNames = s;
-        debugOutput = d;
+        hostname = h;
+        basePath = b;
+        outputToDisk = d;
         return null;
       }
     };
@@ -77,9 +80,10 @@ public class GetDiscoveryDocActionTest extends EndpointsToolTest {
 
   @Test
   public void testMissingOption() throws Exception {
-    tool.execute(new String[]{
-        GetDiscoveryDocAction.NAME, option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT),
-        "classPath", "MyService"});
+    tool.execute(new String[]{GetDiscoveryDocAction.NAME,
+        option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT), "classPath",
+        option(EndpointsToolAction.OPTION_HOSTNAME_SHORT), "foo.com",
+        "MyService"});
     assertFalse(usagePrinted);
     assertThat(Lists.newArrayList(classPath))
         .containsExactly(new File("classPath").toURI().toURL(),
@@ -88,15 +92,15 @@ public class GetDiscoveryDocActionTest extends EndpointsToolTest {
                 .toURI()
                 .toURL());
     assertEquals(EndpointsToolAction.DEFAULT_OUTPUT_PATH, outputDirPath);
-    assertEquals(EndpointsToolAction.DEFAULT_WAR_PATH, warPath);
     assertStringsEqual(Arrays.asList("MyService"), serviceClassNames);
   }
 
   @Test
   public void testMissingArgument() throws Exception {
-    tool.execute(new String[]{
-        GetDiscoveryDocAction.NAME, option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT),
-        "classPath", option(EndpointsToolAction.OPTION_OUTPUT_DIR_SHORT), "outputDir"});
+    tool.execute(new String[]{GetDiscoveryDocAction.NAME,
+        option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT), "classPath",
+        option(EndpointsToolAction.OPTION_OUTPUT_DIR_SHORT), "outputDir",
+        option(EndpointsToolAction.OPTION_HOSTNAME_SHORT), "foo.com"});
     assertTrue(usagePrinted);
   }
 
@@ -105,6 +109,8 @@ public class GetDiscoveryDocActionTest extends EndpointsToolTest {
     tool.execute(new String[]{GetDiscoveryDocAction.NAME,
         option(EndpointsToolAction.OPTION_CLASS_PATH_SHORT), "classPath",
         option(EndpointsToolAction.OPTION_OUTPUT_DIR_SHORT), "outputDir",
+        option(EndpointsToolAction.OPTION_HOSTNAME_SHORT), "foo.com",
+        option(EndpointsToolAction.OPTION_BASE_PATH_SHORT), "/api",
         "MyService", "MyService2"});
     assertFalse(usagePrinted);
     assertThat(Lists.newArrayList(classPath))
@@ -114,8 +120,9 @@ public class GetDiscoveryDocActionTest extends EndpointsToolTest {
                 .toURI()
                 .toURL());
     assertEquals("outputDir", outputDirPath);
-    assertEquals(EndpointsToolAction.DEFAULT_WAR_PATH, warPath);
     assertStringsEqual(Arrays.asList("MyService", "MyService2"), serviceClassNames);
-    assertFalse(debugOutput);
+    assertTrue(outputToDisk);
+    assertThat(hostname).isEqualTo("foo.com");
+    assertThat(basePath).isEqualTo("/api");
   }
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/ServiceContext.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/ServiceContext.java
@@ -27,7 +27,7 @@ public class ServiceContext {
   public static final String DEFAULT_APP_NAME = "myapp";
 
   private final String defaultApiName;
-  private final String appHostName;
+  private final String appHostname;
 
   /**
    * Creates a service context with default application and API name.
@@ -44,37 +44,45 @@ public class ServiceContext {
    * @param apiName Default API name to use.
    */
   public static ServiceContext create(String applicationId, String apiName) {
-    return new ServiceContext(applicationId, apiName);
-  }
-
-  private ServiceContext(String applicationId, String apiName) {
+    String hostname = null;
+    String defaultApiName = null;
     if (applicationId == null || applicationId.trim().isEmpty()) {
       applicationId = DEFAULT_APP_NAME;
     }
-    // For Endpoints runtime, appHostName is generated from App Engine environment directly. When
-    // generating endpoints client library statically from annotated class, derive appHostName from
+    // For Endpoints runtime, appHostname is generated from App Engine environment directly. When
+    // generating endpoints client library statically from annotated class, derive appHostname from
     // application id set in appengine-web.xml.
     int colon = applicationId.indexOf(":");
     if (colon >= 0) {
       String appName = applicationId.substring(colon + 1);
-      this.defaultApiName = apiName == null ? appName : apiName;
+      defaultApiName = apiName == null ? appName : apiName;
       if (applicationId.substring(0, colon).equals("google.com")) {
-        this.appHostName = appName + ".googleplex.com";
+        hostname = appName + ".googleplex.com";
       } else {
         throw new IllegalArgumentException("Invalid application id '" + applicationId + "'");
       }
     } else {
-      this.defaultApiName = apiName == null ? applicationId : apiName;
-      this.appHostName = applicationId + ".appspot.com";
+      defaultApiName = apiName == null ? applicationId : apiName;
+      hostname = applicationId + ".appspot.com";
     }
+    return new ServiceContext(hostname, defaultApiName);
+  }
+
+  public static ServiceContext createFromHostname(String hostname, String apiName) {
+    return new ServiceContext(hostname, apiName);
+  }
+
+  private ServiceContext(String appHostname, String defaultApiName) {
+    this.appHostname = appHostname;
+    this.defaultApiName = defaultApiName;
   }
 
   public String getDefaultApiName() {
     return defaultApiName;
   }
 
-  public String getAppHostName() {
-    return appHostName;
+  public String getAppHostname() {
+    return appHostname;
   }
 
   public String getTransferProtocol() {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiConfig.java
@@ -255,13 +255,13 @@ public class ApiConfig {
    */
   protected void setDefaults(ServiceContext serviceContext) {
     root =
-        serviceContext.getTransferProtocol() + "://" + serviceContext.getAppHostName() + "/_ah/api";
+        serviceContext.getTransferProtocol() + "://" + serviceContext.getAppHostname() + "/_ah/api";
     name = serviceContext.getDefaultApiName();
     canonicalName = null;
     version = "v1";
     description = null;
     backendRoot =
-        serviceContext.getTransferProtocol() + "://" + serviceContext.getAppHostName() + "/_ah/spi";
+        serviceContext.getTransferProtocol() + "://" + serviceContext.getAppHostname() + "/_ah/spi";
     isAbstract = false;
     defaultVersion = true;
     discoverable = true;

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/ServiceContextTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/ServiceContextTest.java
@@ -31,14 +31,14 @@ public class ServiceContextTest {
   @Test
   public void testAppspotHost() {
     ServiceContext c = ServiceContext.create("abc", "xyz");
-    assertEquals("abc.appspot.com", c.getAppHostName());
+    assertEquals("abc.appspot.com", c.getAppHostname());
     assertEquals("xyz", c.getDefaultApiName());
   }
 
   @Test
   public void testGoogleplexHost() {
     ServiceContext c = ServiceContext.create("google.com:abc", "xyz");
-    assertEquals("abc.googleplex.com", c.getAppHostName());
+    assertEquals("abc.googleplex.com", c.getAppHostname());
     assertEquals("xyz", c.getDefaultApiName());
   }
 
@@ -55,7 +55,7 @@ public class ServiceContextTest {
   @Test
   public void testEmptyAppId() {
     ServiceContext c = ServiceContext.create("", "xyz");
-    assertEquals("myapp.appspot.com", c.getAppHostName());
+    assertEquals("myapp.appspot.com", c.getAppHostname());
     assertEquals("xyz", c.getDefaultApiName());
   }
 

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiAnnotationConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiAnnotationConfigTest.java
@@ -59,7 +59,7 @@ public class ApiAnnotationConfigTest {
   public void setUp() throws Exception {
     serviceContext = Mockito.mock(ServiceContext.class);
     Mockito.when(serviceContext.getDefaultApiName()).thenReturn("api");
-    Mockito.when(serviceContext.getAppHostName()).thenReturn("appHostName.com");
+    Mockito.when(serviceContext.getAppHostname()).thenReturn("appHostName.com");
     Mockito.when(serviceContext.getTransferProtocol()).thenReturn("https");
 
     config = new ApiConfig.Factory().create(serviceContext, new TypeLoader(), TestEndpoint.class);

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReaderTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/annotationreader/ApiConfigAnnotationReaderTest.java
@@ -121,7 +121,7 @@ public class ApiConfigAnnotationReaderTest {
 
     serviceContext = Mockito.mock(ServiceContext.class);
     Mockito.when(serviceContext.getDefaultApiName()).thenReturn("api");
-    Mockito.when(serviceContext.getAppHostName()).thenReturn("appHostName.com");
+    Mockito.when(serviceContext.getAppHostname()).thenReturn("appHostName.com");
 
     annotationReader = new ApiConfigAnnotationReader();
   }


### PR DESCRIPTION
App Engine is deprecating app IDs in config and we want to get away from
this model anyway. This change adds --hostname and --path to
get-discovery-doc and get-client-lib to fully specify where an API is
hosted. This involves the following code changes:

* refactor of ServiceContext to allow specifying a hostname instead of
  just an app id
* Renamed the appHostName property to appHostname in ServiceContext
* debug flag in get-discovery-doc is now a no-op. It really already was,
  but now it has been removed from the code except for the interface
  itself so we don't break anyone. It stopped outputting intermediate
  files because there no longer are any.
* small cleanups (removed extra space, unused CLI options, test
  formatting adjustments)