### PR TITLE
hide all private resource fields

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiAnnotationIntrospector.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/annotationreader/ApiAnnotationIntrospector.java
@@ -27,6 +27,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -40,6 +41,7 @@ import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
+import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
 
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
@@ -116,6 +118,12 @@ public class ApiAnnotationIntrospector extends NopAnnotationIntrospector {
   @Override
   public JsonDeserializer<?> findDeserializer(Annotated a) {
     return getJsonDeserializer(findSerializerInstance(a));
+  }
+
+  @Override
+  public VisibilityChecker<?> findAutoDetectVisibility(
+      AnnotatedClass ac, VisibilityChecker<?> checker) {
+    return checker.withSetterVisibility(Visibility.PUBLIC_ONLY);
   }
 
   private static <TFrom, TTo> JsonDeserializer<TFrom> getJsonDeserializer(

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/Foo.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/Foo.java
@@ -27,4 +27,11 @@ public class Foo {
   public int getValue() {
     return 0;
   }
+
+  private String getHidden() {
+    return null;
+  }
+
+  private void setHidden(String hidden) {
+  }
 }


### PR DESCRIPTION
Currently, if a resource field has a private accessor, instance field
and mutator, the resource is still exposed as if it were public. For
some reason, Jackson defaults to allowing mutators of any visibility
level to count as an exposed field, while requiring instance fields and
accessors to be public to count.

This change fixes a longstanding (from v1) bug by hiding such
cases. Resources will now only have exposed fields when at least one
part of the field declaration (field itself, accessor, or mutator) is
public.