### PR TITLE
fix hostname generation in get-client-lib

### DIFF
--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/EndpointsToolAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/EndpointsToolAction.java
@@ -230,7 +230,11 @@ public abstract class EndpointsToolAction extends Action {
     if (hostnameOption.getValue() != null) {
       return hostnameOption.getValue();
     }
-    return AppEngineUtil.getApplicationDefaultHostname(warPath);
+    String defaultHostname = AppEngineUtil.getApplicationDefaultHostname(warPath);
+    if (defaultHostname != null) {
+      return defaultHostname;
+    }
+    return DEFAULT_HOSTNAME;
   }
 
   protected String getBasePath(Option basePathOption) {

--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetClientLibAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GetClientLibAction.java
@@ -82,7 +82,7 @@ public class GetClientLibAction extends EndpointsToolAction {
       List<String> serviceClassNames, String buildSystem, String hostname, String basePath,
       boolean debug) throws ClassNotFoundException, IOException, ApiConfigException {
     Map<String, String> discoveryDocs = new GetDiscoveryDocAction().getDiscoveryDoc(
-        classPath, outputDirPath, serviceClassNames, basePath, hostname, debug /* outputToDisk */);
+        classPath, outputDirPath, serviceClassNames, hostname, basePath, debug /* outputToDisk */);
     for (Map.Entry<String, String> entry : discoveryDocs.entrySet()) {
       new GenClientLibAction().genClientLib(language, outputDirPath, entry.getValue(), buildSystem);
     }


### PR DESCRIPTION
* get-client-lib reversed the hostname and base path parameters sent to
  GetDiscoveryDocAction.
* get-client-lib gave a null hostname rather than myapp.appspot.com if
  -h and appengine-web.xml didn't have an app id.