### PR TITLE
Update proxy.html

### DIFF
--- a/endpoints-framework/src/main/resources/com/google/api/server/spi/handlers/proxy.html
+++ b/endpoints-framework/src/main/resources/com/google/api/server/spi/handlers/proxy.html
@@ -1,3 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title></title>
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 <!--
 Copyright 2016 Google Inc. All Rights Reserved.
 
@@ -13,19 +18,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<!doctype html>
-<html>
-<head>
-<title></title>
 <script type="text/javascript">
   window['startup'] = function() {
-    googleapis.server.initWithPath('/_ah/api');
+    googleapis.server.init();
   };
 </script>
 <script type="text/javascript"
     src="https://apis.google.com/js/googleapis.proxy.js?onload=startup" async defer></script>
 </head>
 <body>
-  <div id="lcsclient" style="position: absolute; left: -10000px;"></div>
 </body>
 </html>


### PR DESCRIPTION
Hi @tangiel (and you might care about this too, @bochunz )

I'm proposing updating this proxy iframe HTML as follows:
- <!DOCTYPE ...> declaration must be upper-case for HTML 5/MSIE compatibility
- add <meta http-equiv="X-UA-Compatible" ...> for MSIE compatibility to avoid rendering mode/feature skew (e.g. postMessage, CORS, etc.) vs. parent frames/pages
- switch to googleapis.server.init as that knows how to enforce /_ah/api and other similar path restrictions provided there's a /static/proxy.html suffix, and fails safe otherwise
- remove unused lcsclient
- move HTML comment (copyright+license notice) after initial parts of document so that browsers only reading the first bytes for content-sniffing/mode-detection do the right thing