### PR TITLE
update OpenApi spec generation to new auth format

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiIssuerAudienceConfig.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiIssuerAudienceConfig.java
@@ -18,6 +18,8 @@ package com.google.api.server.spi.config.model;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import java.util.Collection;
 import java.util.Objects;
 
@@ -31,7 +33,7 @@ public class ApiIssuerAudienceConfig {
       .addIssuerAudiences(UNSPECIFIED_NAME, UNSPECIFIED_AUDIENCE)
       .build();
   public static final ApiIssuerAudienceConfig EMPTY = builder().build();
-  private final ImmutableListMultimap<String, String> issuerAudiences;
+  private final ImmutableSetMultimap<String, String> issuerAudiences;
 
   private ApiIssuerAudienceConfig(ApiIssuerAudienceConfig.Builder builder) {
     this.issuerAudiences = builder.issuerAudiences.build();
@@ -53,6 +55,14 @@ public class ApiIssuerAudienceConfig {
     return issuerAudiences.containsKey(issuer);
   }
 
+  public ImmutableSet<String> getIssuerNames() {
+    return issuerAudiences.keySet();
+  }
+
+  public ImmutableSet<String> getAudiences(String issuer) {
+    return issuerAudiences.get(issuer);
+  }
+
   @Override
   public boolean equals(Object o) {
     return o != null && o instanceof ApiIssuerAudienceConfig
@@ -69,8 +79,8 @@ public class ApiIssuerAudienceConfig {
   }
 
   public static class Builder {
-    private final ImmutableListMultimap.Builder<String, String> issuerAudiences =
-        ImmutableListMultimap.builder();
+    private final ImmutableSetMultimap.Builder<String, String> issuerAudiences =
+        ImmutableSetMultimap.builder();
 
     public Builder addIssuerAudiences(String issuer, String... audiences) {
       issuerAudiences.putAll(issuer, audiences);

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiIssuerConfigs.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/ApiIssuerConfigs.java
@@ -34,6 +34,10 @@ public class ApiIssuerConfigs {
     return issuerConfigs.containsKey(issuer);
   }
 
+  public IssuerConfig getIssuer(String issuer) {
+    return issuerConfigs.get(issuer);
+  }
+
   public boolean isSpecified() {
     return !this.equals(UNSPECIFIED);
   }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiIssuerAudienceConfigTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/model/ApiIssuerAudienceConfigTest.java
@@ -2,8 +2,7 @@ package com.google.api.server.spi.config.model;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.ImmutableList;
-
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,7 +30,7 @@ public class ApiIssuerAudienceConfigTest {
     ApiIssuerAudienceConfig config = ApiIssuerAudienceConfig.builder()
         .addIssuerAudiences("issuer", "aud1", "aud2")
         .build();
-    assertThat(config.asMap()).containsExactly("issuer", ImmutableList.of("aud1", "aud2"));
+    assertThat(config.asMap()).containsExactly("issuer", ImmutableSet.of("aud1", "aud2"));
   }
 
   @Test

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
@@ -39,10 +39,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -59,10 +59,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       }
@@ -90,10 +90,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -109,8 +109,8 @@
             "type": "string"
           },
           {
-            "name": "body",
             "in": "body",
+            "name": "body",
             "required": false,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -127,10 +127,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -146,8 +146,8 @@
             "type": "string"
           },
           {
-            "name": "body",
             "in": "body",
+            "name": "body",
             "required": false,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -164,10 +164,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -193,29 +193,31 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       }
     }
   },
   "securityDefinitions": {
-    "google_id_token_https": {
-      "type": "oauth2",
-      "authorizationUrl": "",
-      "flow": "implicit",
-      "x-google-issuer": "https://accounts.google.com",
-      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
-    },
-    "google_id_token": {
+    "google_id_token-3a26ea04": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
       "x-google-issuer": "accounts.google.com",
-      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs",
+      "x-google-audiences": "audience"
+    },
+    "google_id_token_https-3a26ea04": {
+      "type": "oauth2",
+      "authorizationUrl": "",
+      "flow": "implicit",
+      "x-google-issuer": "https://accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs",
+      "x-google-audiences": "audience"
     }
   },
   "definitions": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
@@ -39,10 +39,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -59,10 +59,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       }
@@ -90,10 +90,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -109,8 +109,8 @@
             "type": "string"
           },
           {
-            "name": "body",
             "in": "body",
+            "name": "body",
             "required": false,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -127,10 +127,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -146,8 +146,8 @@
             "type": "string"
           },
           {
-            "name": "body",
             "in": "body",
+            "name": "body",
             "required": false,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -164,10 +164,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -193,29 +193,31 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       }
     }
   },
   "securityDefinitions": {
-    "google_id_token_https": {
-      "type": "oauth2",
-      "authorizationUrl": "",
-      "flow": "implicit",
-      "x-google-issuer": "https://accounts.google.com",
-      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
-    },
-    "google_id_token": {
+    "google_id_token-3a26ea04": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
       "x-google-issuer": "accounts.google.com",
-      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs",
+      "x-google-audiences": "audience"
+    },
+    "google_id_token_https-3a26ea04": {
+      "type": "oauth2",
+      "authorizationUrl": "",
+      "flow": "implicit",
+      "x-google-issuer": "https://accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs",
+      "x-google-audiences": "audience"
     }
   },
   "definitions": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
@@ -39,26 +39,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
-          }
-        ],
-        "x-security": [
-          {
-            "google_id_token": {
-              "audiences": [
-                "audience"
-              ]
-            }
-          },
-          {
-            "google_id_token_https": {
-              "audiences": [
-                "audience"
-              ]
-            }
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -75,26 +59,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
-          }
-        ],
-        "x-security": [
-          {
-            "google_id_token": {
-              "audiences": [
-                "audience"
-              ]
-            }
-          },
-          {
-            "google_id_token_https": {
-              "audiences": [
-                "audience"
-              ]
-            }
+            "google_id_token_https-3a26ea04": []
           }
         ]
       }
@@ -122,26 +90,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
-          }
-        ],
-        "x-security": [
-          {
-            "google_id_token": {
-              "audiences": [
-                "audience"
-              ]
-            }
-          },
-          {
-            "google_id_token_https": {
-              "audiences": [
-                "audience"
-              ]
-            }
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -157,8 +109,8 @@
             "type": "string"
           },
           {
-            "name": "body",
             "in": "body",
+            "name": "body",
             "required": false,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -175,26 +127,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
-          }
-        ],
-        "x-security": [
-          {
-            "google_id_token": {
-              "audiences": [
-                "audience"
-              ]
-            }
-          },
-          {
-            "google_id_token_https": {
-              "audiences": [
-                "audience"
-              ]
-            }
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -210,8 +146,8 @@
             "type": "string"
           },
           {
-            "name": "body",
             "in": "body",
+            "name": "body",
             "required": false,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -228,26 +164,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
-          }
-        ],
-        "x-security": [
-          {
-            "google_id_token": {
-              "audiences": [
-                "audience"
-              ]
-            }
-          },
-          {
-            "google_id_token_https": {
-              "audiences": [
-                "audience"
-              ]
-            }
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -273,45 +193,31 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
-          }
-        ],
-        "x-security": [
-          {
-            "google_id_token": {
-              "audiences": [
-                "audience"
-              ]
-            }
-          },
-          {
-            "google_id_token_https": {
-              "audiences": [
-                "audience"
-              ]
-            }
+            "google_id_token_https-3a26ea04": []
           }
         ]
       }
     }
   },
   "securityDefinitions": {
-    "google_id_token_https": {
-      "type": "oauth2",
-      "authorizationUrl": "",
-      "flow": "implicit",
-      "x-google-issuer": "https://accounts.google.com",
-      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
-    },
-    "google_id_token": {
+    "google_id_token-3a26ea04": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
       "x-google-issuer": "accounts.google.com",
-      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs",
+      "x-google-audiences": "audience"
+    },
+    "google_id_token_https-3a26ea04": {
+      "type": "oauth2",
+      "authorizationUrl": "",
+      "flow": "implicit",
+      "x-google-issuer": "https://accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs",
+      "x-google-audiences": "audience"
     }
   },
   "definitions": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
@@ -39,10 +39,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -59,10 +59,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       }
@@ -90,10 +90,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -109,8 +109,8 @@
             "type": "string"
           },
           {
-            "name": "body",
             "in": "body",
+            "name": "body",
             "required": false,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -127,10 +127,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -146,8 +146,8 @@
             "type": "string"
           },
           {
-            "name": "body",
             "in": "body",
+            "name": "body",
             "required": false,
             "schema": {
               "$ref": "#/definitions/Foo"
@@ -164,10 +164,10 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       },
@@ -193,29 +193,31 @@
         },
         "security": [
           {
-            "google_id_token": []
+            "google_id_token-3a26ea04": []
           },
           {
-            "google_id_token_https": []
+            "google_id_token_https-3a26ea04": []
           }
         ]
       }
     }
   },
   "securityDefinitions": {
-    "google_id_token_https": {
-      "type": "oauth2",
-      "authorizationUrl": "",
-      "flow": "implicit",
-      "x-google-issuer": "https://accounts.google.com",
-      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
-    },
-    "google_id_token": {
+    "google_id_token-3a26ea04": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
       "x-google-issuer": "accounts.google.com",
-      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs",
+      "x-google-audiences": "audience"
+    },
+    "google_id_token_https-3a26ea04": {
+      "type": "oauth2",
+      "authorizationUrl": "",
+      "flow": "implicit",
+      "x-google-issuer": "https://accounts.google.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs",
+      "x-google-audiences": "audience"
     }
   },
   "definitions": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
@@ -27,16 +27,7 @@
         },
         "security": [
           {
-            "auth0": []
-          }
-        ],
-        "x-security": [
-          {
-            "auth0": {
-              "audiences": [
-                "auth0audmethod"
-              ]
-            }
+            "auth0-6fa4a909": []
           }
         ]
       }
@@ -52,16 +43,7 @@
         },
         "security": [
           {
-            "google_id_token": []
-          }
-        ],
-        "x-security": [
-          {
-            "google_id_token": {
-              "audiences": [
-                "googleaud"
-              ]
-            }
+            "google_id_token-57e345d7": []
           }
         ]
       }
@@ -77,48 +59,36 @@
         },
         "security": [
           {
-            "auth0": []
-          }
-        ],
-        "x-security": [
-          {
-            "auth0": {
-              "audiences": [
-                "auth0audapi"
-              ]
-            }
+            "auth0-a05d2f2": []
           }
         ]
       }
     }
   },
   "securityDefinitions": {
-    "auth0": {
+    "auth0-6fa4a909": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
       "x-google-issuer": "https://test.auth0.com/authorize",
-      "x-google-jwks_uri": "https://test.auth0.com/.wellknown/jwks.json"
+      "x-google-jwks_uri": "https://test.auth0.com/.wellknown/jwks.json",
+      "x-google-audiences": "auth0audmethod"
     },
-    "nojwks": {
-      "type": "oauth2",
-      "authorizationUrl": "",
-      "flow": "implicit",
-      "x-google-issuer": "https://nojwks.com"
-    },
-    "google_id_token": {
+    "google_id_token-57e345d7": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
       "x-google-issuer": "accounts.google.com",
-      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs",
+      "x-google-audiences": "googleaud"
     },
-    "google_id_token_https": {
+    "auth0-a05d2f2": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-google-issuer": "https://accounts.google.com",
-      "x-google-jwks_uri": "https://www.googleapis.com/oauth2/v1/certs"
+      "x-google-issuer": "https://test.auth0.com/authorize",
+      "x-google-jwks_uri": "https://test.auth0.com/.wellknown/jwks.json",
+      "x-google-audiences": "auth0audapi"
     }
   }
 }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/third_party_auth.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/third_party_auth.swagger
@@ -27,16 +27,7 @@
         },
         "security": [
           {
-            "auth0": []
-          }
-        ],
-        "x-security": [
-          {
-            "auth0": {
-              "audiences": [
-                "auth0audmethod"
-              ]
-            }
+            "auth0-6fa4a909": []
           }
         ]
       }
@@ -52,34 +43,28 @@
         },
         "security": [
           {
-            "auth0": []
-          }
-        ],
-        "x-security": [
-          {
-            "auth0": {
-              "audiences": [
-                "auth0audapi"
-              ]
-            }
+            "auth0-a05d2f2": []
           }
         ]
       }
     }
   },
   "securityDefinitions": {
-    "auth0": {
+    "auth0-6fa4a909": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
       "x-google-issuer": "https://test.auth0.com/authorize",
-      "x-google-jwks_uri": "https://test.auth0.com/.wellknown/jwks.json"
+      "x-google-jwks_uri": "https://test.auth0.com/.wellknown/jwks.json",
+      "x-google-audiences": "auth0audmethod"
     },
-    "nojwks": {
+    "auth0-a05d2f2": {
       "type": "oauth2",
       "authorizationUrl": "",
       "flow": "implicit",
-      "x-google-issuer": "https://nojwks.com"
+      "x-google-issuer": "https://test.auth0.com/authorize",
+      "x-google-jwks_uri": "https://test.auth0.com/.wellknown/jwks.json",
+      "x-google-audiences": "auth0audapi"
     }
   }
 }


### PR DESCRIPTION
The new auth format specifies audiences in the OpenAPI security
definitions block, rather than using the x-security vendor
extension. To handle this, we now declare one security definition per
issuer-audience set combination. The security definition is given the
name of the issuer plus a hash of the audience set in hexadecimal.