### PR TITLE
include query parameters in parameterOrder field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 jdk:
   - openjdk7
+install:
+ - JAVA_HOME=$(jdk_switcher home openjdk8) ./gradlew classes testClasses
 after_success:
   - ./gradlew jacocoTestReport
   - bash <(curl -s https://codecov.io/bash)

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/DiscoveryGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/DiscoveryGenerator.java
@@ -195,10 +195,8 @@ public class DiscoveryGenerator {
         .setId(methodConfig.getFullMethodName())
         .setPath(methodConfig.getCanonicalPath().substring(servicePath.length()))
         .setScopes(AuthScopeExpressions.encodeMutable(methodConfig.getScopeExpression()));
-    if (!methodConfig.getPathParameters().isEmpty()) {
-      method.setParameterOrder(Lists.newArrayList(parameters.keySet()));
-    }
     if (!parameters.isEmpty()) {
+      method.setParameterOrder(Lists.newArrayList(parameters.keySet()));
       method.setParameters(parameters);
     }
     ApiParameterConfig requestParamConfig = getAndCheckMethodRequestResource(methodConfig);

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_endpoint.json
@@ -159,6 +159,9 @@
           "description": "list desc",
           "httpMethod": "GET",
           "id": "foo.foo.list",
+          "parameterOrder": [
+            "n"
+          ],
           "parameters": {
             "n": {
               "format": "int32",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_endpoint_default_context.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_endpoint_default_context.json
@@ -159,6 +159,9 @@
           "description": "list desc",
           "httpMethod": "GET",
           "id": "foo.foo.list",
+          "parameterOrder": [
+            "n"
+          ],
           "parameters": {
             "n": {
               "format": "int32",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_endpoint_localhost.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_endpoint_localhost.json
@@ -159,6 +159,9 @@
           "description": "list desc",
           "httpMethod": "GET",
           "id": "foo.foo.list",
+          "parameterOrder": [
+            "n"
+          ],
           "parameters": {
             "n": {
               "format": "int32",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/multiple_parameter_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/multiple_parameter_endpoint.json
@@ -25,15 +25,20 @@
       "id": "multipleparam.param",
       "parameterOrder": [
         "parent",
+        "query",
         "child"
       ],
       "parameters": {
-        "child": {
+        "parent": {
           "location": "path",
           "required": true,
           "type": "string"
         },
-        "parent": {
+        "query": {
+          "location": "query",
+          "type": "string"
+        },
+        "child": {
           "location": "path",
           "required": true,
           "type": "string"

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/MultipleParameterEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/MultipleParameterEndpoint.java
@@ -3,6 +3,7 @@ package com.google.api.server.spi.testing;
 import com.google.api.server.spi.config.Api;
 import com.google.api.server.spi.config.ApiMethod;
 import com.google.api.server.spi.config.Named;
+import com.google.api.server.spi.config.Nullable;
 
 /**
  * This endpoint is used for testing that named parameters are output in order.
@@ -10,5 +11,8 @@ import com.google.api.server.spi.config.Named;
 @Api(name = "multipleparam", version = "v1")
 public class MultipleParameterEndpoint {
   @ApiMethod(name = "param", path = "param/{parent}/{child}")
-  public void param(@Named("parent") String parent, @Named("child") String child) { }
+  public void param(
+      @Named("parent") String parent,
+      @Named("query") @Nullable String query,
+      @Named("child") String child) { }
 }


### PR DESCRIPTION
Discovery has a parameterOrder field. This is seemingly used to
document the order of parameters for use in client library
generation. Previously, we were only including path parameters, but we
need to include query parameters, so that the order is deterministic.