### PR TITLE
support AuthLevel.REQUIRED annotation

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/RestServletRequestParamReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/RestServletRequestParamReader.java
@@ -58,7 +58,7 @@ public class RestServletRequestParamReader extends ServletRequestParamReader {
       HttpServletRequest servletRequest, ServletContext servletContext,
       ApiSerializationConfig serializationConfig, ApiMethodConfig methodConfig,
       Map<String, String> rawPathParameters) {
-    super(method, servletRequest, servletContext, serializationConfig);
+    super(method, servletRequest, servletContext, serializationConfig, methodConfig);
     this.rawPathParameters = rawPathParameters;
     ImmutableMap.Builder<String, ApiParameterConfig> builder = ImmutableMap.builder();
     for (ApiParameterConfig config : methodConfig.getParameterConfigs()) {


### PR DESCRIPTION
It is currently not easy to support all AuthLevel modes, but REQUIRED
is likely to be the the most used and easy to implement, so support is
added here.