### PR TITLE
fix JWT + API key auth config generation

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -340,7 +340,17 @@ public class SwaggerGenerator {
     operation.response(200, response);
     writeAuthConfig(swagger, methodConfig, operation);
     if (methodConfig.isApiKeyRequired()) {
-      operation.addSecurity(API_KEY, ImmutableList.<String>of());
+      List<Map<String, List<String>>> security = operation.getSecurity();
+      // Loop through each existing security requirement for this method, which is currently just a
+      // JWT config id, and add an API key requirement to it. If there are currently no new
+      // security requirements, add a new one for just the API key.
+      if (security != null) {
+        for (Map<String, List<String>> securityEntry : security) {
+          securityEntry.put(API_KEY, ImmutableList.<String>of());
+        }
+      } else {
+        operation.addSecurity(API_KEY, ImmutableList.<String>of());
+      }
       Map<String, SecuritySchemeDefinition> definitions = swagger.getSecurityDefinitions();
       if (definitions == null || !definitions.containsKey(API_KEY)) {
         swagger.securityDefinition(API_KEY, new ApiKeyAuthDefinition(API_KEY_PARAM, In.QUERY));

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/swagger/SwaggerGeneratorTest.java
@@ -211,6 +211,10 @@ public class SwaggerGeneratorTest {
   }
 
   @Api(name = "apikeys", version = "v1",
+      issuers = {
+          @ApiIssuer(name = "auth0", issuer = "https://test.auth0.com/authorize",
+              jwksUri = "https://test.auth0.com/.wellknown/jwks.json")
+      },
       apiKeyRequired = AnnotationBoolean.TRUE)
   private static class ApiKeysEndpoint {
     @ApiMethod(apiKeyRequired = AnnotationBoolean.FALSE)
@@ -218,5 +222,11 @@ public class SwaggerGeneratorTest {
 
     @ApiMethod
     public void inheritApiKeySetting() { }
+
+    @ApiMethod(
+        issuerAudiences = {
+            @ApiIssuerAudience(name = "auth0", audiences = "auth0audmethod")
+        })
+    public void apiKeyWithAuth() { }
   }
 }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/api_keys.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/api_keys.swagger
@@ -16,6 +16,23 @@
     "application/json"
   ],
   "paths": {
+    "/apikeys/v1/apiKeyWithAuth": {
+      "post": {
+        "operationId": "ApikeysApiKeyWithAuth",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A successful response"
+          }
+        },
+        "security": [
+          {
+            "auth0-6fa4a909": [],
+            "api_key": []
+          }
+        ]
+      }
+    },
     "/apikeys/v1/inheritApiKeySetting": {
       "post": {
         "operationId": "ApikeysInheritApiKeySetting",
@@ -45,6 +62,14 @@
     }
   },
   "securityDefinitions": {
+    "auth0-6fa4a909": {
+      "type": "oauth2",
+      "authorizationUrl": "",
+      "flow": "implicit",
+      "x-google-issuer": "https://test.auth0.com/authorize",
+      "x-google-jwks_uri": "https://test.auth0.com/.wellknown/jwks.json",
+      "x-google-audiences": "auth0audmethod"
+    },
     "api_key": {
       "type": "apiKey",
       "name": "key",


### PR DESCRIPTION
Right now, if wishing to use JWT auth plus API keys, the OpenAPI
config generator places the API key in a separate security
requirement, which allows JWT auth OR API key. This change adds the
API key to every existing security requirement to change OR to AND. If
no current security requirements exist, a new one is created to solely
allow API key validation.