### PR TITLE
allow null error fields

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/response/RestResponseResultWriter.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/response/RestResponseResultWriter.java
@@ -15,6 +15,10 @@
  */
 package com.google.api.server.spi.response;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.api.server.spi.ObjectMapperUtil;
 import com.google.api.server.spi.ServiceException;
 import com.google.api.server.spi.config.model.ApiSerializationConfig;
 import com.google.common.base.Strings;
@@ -31,12 +35,14 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class RestResponseResultWriter extends ServletResponseResultWriter {
   private final boolean enableExceptionCompatibility;
+  private final ObjectMapper objectMapper;
 
   public RestResponseResultWriter(
       HttpServletResponse servletResponse, ApiSerializationConfig serializationConfig,
       boolean prettyPrint, boolean enableExceptionCompatibility) {
     super(servletResponse, serializationConfig, prettyPrint);
     this.enableExceptionCompatibility = enableExceptionCompatibility;
+    this.objectMapper = ObjectMapperUtil.createStandardObjectMapper(serializationConfig);
   }
 
   /**
@@ -69,15 +75,16 @@ public class RestResponseResultWriter extends ServletResponseResultWriter {
   }
 
   private Object createError(int code, String reason, String domain, String message) {
-    return ImmutableMap.of(
-        "error", ImmutableMap.of(
-            "errors", ImmutableList.of(ImmutableMap.of(
-                "domain", domain,
-                "reason", reason,
-                "message", message
-            )),
-            "code", code,
-            "message", message
-        ));
+    ObjectNode topLevel = objectMapper.createObjectNode();
+    ObjectNode topError = objectMapper.createObjectNode();
+    ObjectNode error = objectMapper.createObjectNode();
+    error.put("domain", domain);
+    error.put("reason", reason);
+    error.put("message", message);
+    topError.set("errors", objectMapper.createArrayNode().add(error));
+    topError.put("code", code);
+    topError.put("message", message);
+    topLevel.set("error", topError);
+    return topLevel;
   }
 }


### PR DESCRIPTION
Currently a NullPointerException is thrown due to disallowed null
values in ImmutableMap. This change changes error construction to use
Jackson data to allow for null values.