### PR TITLE
Add description on enum constants

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/Description.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/Description.java
@@ -21,7 +21,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to specify the description of an API parameter.
+ * Annotation to specify the description of an API parameter or enum constants.
+ * The description will be ignored if the annotation is used on resource fields.
  */
 @Target({ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
@@ -152,15 +152,13 @@ public class SchemaRepository {
       return MAP_SCHEMA;
     } else if (Types.isEnumType(type)) {
       Schema.Builder builder = Schema.builder()
-          .setName(Types.getSimpleName(type, config.getSerializationConfig()))
-          .setType("string");
-      for (Object enumConstant : type.getRawType().getEnumConstants()) {
-        builder.addEnumValue(((Enum) enumConstant).name());
-        try {
-          final Description description = enumConstant.getClass().getField(((Enum) enumConstant).name()).getAnnotation(Description.class);
+              .setName(Types.getSimpleName(type, config.getSerializationConfig()))
+              .setType("string");
+      for (java.lang.reflect.Field field : type.getRawType().getFields()) {
+        if (field.isEnumConstant()) {
+          builder.addEnumValue(field.getName());
+          Description description = field.getAnnotation(Description.class);
           builder.addEnumDescription(description == null ? "" : description.value());
-        } catch (NoSuchFieldException e) {
-          builder.addEnumDescription("");
         }
       }
       schema = builder.build();

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
@@ -2,6 +2,7 @@ package com.google.api.server.spi.config.model;
 
 import com.google.api.client.util.Maps;
 import com.google.api.server.spi.TypeLoader;
+import com.google.api.server.spi.config.Description;
 import com.google.api.server.spi.config.ResourcePropertySchema;
 import com.google.api.server.spi.config.ResourceSchema;
 import com.google.api.server.spi.config.annotationreader.ApiAnnotationIntrospector;
@@ -155,7 +156,12 @@ public class SchemaRepository {
           .setType("string");
       for (Object enumConstant : type.getRawType().getEnumConstants()) {
         builder.addEnumValue(((Enum) enumConstant).name());
-        builder.addEnumDescription("");
+        try {
+          final Description description = enumConstant.getClass().getField(((Enum) enumConstant).name()).getAnnotation(Description.class);
+          builder.addEnumDescription(description == null ? "" : description.value());
+        } catch (NoSuchFieldException e) {
+          builder.addEnumDescription("");
+        }
       }
       schema = builder.build();
       typesForConfig.put(type, schema);

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
@@ -152,8 +152,8 @@ public class SchemaRepository {
       return MAP_SCHEMA;
     } else if (Types.isEnumType(type)) {
       Schema.Builder builder = Schema.builder()
-              .setName(Types.getSimpleName(type, config.getSerializationConfig()))
-              .setType("string");
+          .setName(Types.getSimpleName(type, config.getSerializationConfig()))
+          .setType("string");
       for (java.lang.reflect.Field field : type.getRawType().getFields()) {
         if (field.isEnumConstant()) {
           builder.addEnumValue(field.getName());

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
@@ -154,7 +154,7 @@ public class SchemaRepository {
           .setName(Types.getSimpleName(type, config.getSerializationConfig()))
           .setType("string");
       for (Object enumConstant : type.getRawType().getEnumConstants()) {
-        builder.addEnumValue(enumConstant.toString());
+        builder.addEnumValue(((Enum) enumConstant).name());
         builder.addEnumDescription("");
       }
       schema = builder.build();

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/DiscoveryGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/DiscoveryGenerator.java
@@ -238,7 +238,9 @@ public class DiscoveryGenerator {
 
   private JsonSchema convertToDiscoverySchema(Field f) {
     if (f.schemaReference() != null) {
-      return new JsonSchema().set$ref(f.schemaReference().get().name());
+      return new JsonSchema()
+          .setDescription(f.description())
+          .set$ref(f.schemaReference().get().name());
     }
     JsonSchema fieldSchema = new JsonSchema()
         .setType(f.type().getDiscoveryType())

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/config/jsonwriter/ResourceSchemaProviderTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/config/jsonwriter/ResourceSchemaProviderTest.java
@@ -31,6 +31,7 @@ import com.google.api.server.spi.config.ResourceTransformer;
 import com.google.api.server.spi.config.model.ApiConfig;
 import com.google.api.server.spi.testing.DefaultValueSerializer;
 import com.google.api.server.spi.testing.TestEndpoint;
+import com.google.api.server.spi.testing.TestEnum;
 import com.google.common.reflect.TypeToken;
 
 import org.junit.Before;
@@ -77,6 +78,7 @@ public abstract class ResourceSchemaProviderTest {
     ResourceSchema schema = getResourceSchema(DescribedPropertyBean.class);
     assertEquals("description of foo", schema.getProperties().get("foo").getDescription());
     assertEquals("description of bar", schema.getProperties().get("bar").getDescription());
+    assertEquals("description of choice", schema.getProperties().get("choice").getDescription());
   }
 
   @Test
@@ -197,6 +199,8 @@ public abstract class ResourceSchemaProviderTest {
     public String getBar() {
       return null;
     }
+    @ApiResourceProperty(description = "description of choice")
+    public TestEnum choice;
   }
 
   /**

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoveryGeneratorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/discovery/DiscoveryGeneratorTest.java
@@ -32,6 +32,7 @@ import com.google.api.server.spi.testing.AbsolutePathEndpoint;
 import com.google.api.server.spi.testing.ArrayEndpoint;
 import com.google.api.server.spi.testing.EnumEndpoint;
 import com.google.api.server.spi.testing.EnumEndpointV2;
+import com.google.api.server.spi.testing.FooDescriptionEndpoint;
 import com.google.api.server.spi.testing.FooEndpoint;
 import com.google.api.server.spi.testing.MultipleParameterEndpoint;
 import com.google.api.server.spi.testing.NamespaceEndpoint;
@@ -160,6 +161,13 @@ public class DiscoveryGeneratorTest {
     getDiscovery(new DiscoveryContext(), EnumEndpointV2.class);
     RestDescription doc = getDiscovery(new DiscoveryContext(), EnumEndpoint.class);
     RestDescription expected = readExpectedAsDiscovery("enum_endpoint.json");
+    compareDiscovery(expected, doc);
+  }
+
+  @Test
+  public void testWriteDiscovery_FooEndpointWithDescription() throws Exception {
+    RestDescription doc = getDiscovery(context, FooDescriptionEndpoint.class);
+    RestDescription expected = readExpectedAsDiscovery("foo_with_description_endpoint.json");
     compareDiscovery(expected, doc);
   }
 

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_with_description_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_with_description_endpoint.json
@@ -229,7 +229,8 @@
       "id": "FooDescription",
       "properties": {
         "choice": {
-          "$ref":"TestEnumDescription"
+          "$ref": "TestEnumDescription",
+          "description": "description of choice"
         },
         "name": {
           "description":"description of name",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_with_description_endpoint.json
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/discovery/foo_with_description_endpoint.json
@@ -1,0 +1,260 @@
+{
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/userinfo.email": {
+          "description": "View your email address"
+        }
+      }
+    }
+  },
+  "basePath": "/api/foo/v1/",
+  "baseUrl": "https://discovery-test.appspot.com/api/foo/v1/",
+  "batchPath": "batch",
+  "description": "Just Foo Things",
+  "discoveryVersion": "v1",
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  },
+  "id": "foo:v1",
+  "kind": "discovery#restDescription",
+  "methods": {
+    "toplevel": {
+      "httpMethod": "POST",
+      "id": "foo.toplevel",
+      "path": "foos",
+      "response": {
+        "$ref": "CollectionResponse_FooDescription"
+      },
+      "scopes": [
+        "https://www.googleapis.com/auth/userinfo.email"
+      ]
+    }
+  },
+  "name": "foo",
+  "parameters": {
+    "alt": {
+      "default": "json",
+      "description": "Data format for the response.",
+      "enum": [
+        "json"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json"
+      ],
+      "location": "query",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query",
+      "type": "string"
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query",
+      "type": "string"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "default": "true",
+      "description": "Returns response with indentations and line breaks.",
+      "location": "query",
+      "type": "boolean"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+      "location": "query",
+      "type": "string"
+    },
+    "userIp": {
+      "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+      "location": "query",
+      "type": "string"
+    }
+  },
+  "protocol": "rest",
+  "resources": {
+    "foo": {
+      "methods": {
+        "create": {
+          "description": "create desc",
+          "httpMethod": "PUT",
+          "id": "foo.foo.create",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "description": "id desc",
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "foos/{id}",
+          "request": {
+            "$ref": "FooDescription",
+            "parameterName": "resource"
+          },
+          "response": {
+            "$ref": "FooDescription"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "delete": {
+          "description": "delete desc",
+          "httpMethod": "DELETE",
+          "id": "foo.foo.delete",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "description": "id desc",
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "foos/{id}",
+          "response": {
+            "$ref": "FooDescription"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "get": {
+          "description": "get desc",
+          "httpMethod": "GET",
+          "id": "foo.foo.get",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "description": "id desc",
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "foos/{id}",
+          "response": {
+            "$ref": "FooDescription"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "list": {
+          "description": "list desc",
+          "httpMethod": "GET",
+          "id": "foo.foo.list",
+          "parameterOrder": [
+            "n"
+          ],
+          "parameters": {
+            "n": {
+              "format": "int32",
+              "location": "query",
+              "required": true,
+              "type": "integer"
+            }
+          },
+          "path": "foos",
+          "response": {
+            "$ref": "CollectionResponse_FooDescription"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        },
+        "update": {
+          "description": "update desc",
+          "httpMethod": "POST",
+          "id": "foo.foo.update",
+          "parameterOrder": [
+            "id"
+          ],
+          "parameters": {
+            "id": {
+              "description": "id desc",
+              "location": "path",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "foos/{id}",
+          "request": {
+            "$ref": "FooDescription",
+            "parameterName": "resource"
+          },
+          "response": {
+            "$ref": "FooDescription"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/userinfo.email"
+          ]
+        }
+      }
+    }
+  },
+  "rootUrl": "https://discovery-test.appspot.com/api/",
+  "schemas": {
+    "CollectionResponse_FooDescription": {
+      "id": "CollectionResponse_FooDescription",
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "FooDescription"
+          },
+          "type": "array"
+        },
+        "nextPageToken": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "FooDescription": {
+      "id": "FooDescription",
+      "properties": {
+        "choice": {
+          "$ref":"TestEnumDescription"
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "TestEnumDescription": {
+      "enum": [
+        "VALUE1",
+        "VALUE2"
+      ],
+      "enumDescriptions": [
+        "description of value1",
+        "description of value2"
+      ],
+      "id": "TestEnumDescription",
+      "type":"string"
+    }
+  },
+  "servicePath": "foo/v1/",
+  "title": "The Foo API",
+  "version": "v1"
+}

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/FooDescription.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/FooDescription.java
@@ -26,6 +26,7 @@ public class FooDescription {
   private String name;
   private int value;
   private String hidden;
+  @ApiResourceProperty(description = "description of choice")
   private TestEnumDescription choice;
 
   public String getName() {

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/FooDescription.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/FooDescription.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.server.spi.testing;
+
+import com.google.api.server.spi.config.Description;
+
+/**
+ * Test resource type with descriptions.
+ */
+public class FooDescription {
+
+  @Description("description of name")
+  private String name;
+  @Description("description of value")
+  private int value;
+  private String hidden;
+  @Description("description of choice")
+  private TestEnumDescription choice;
+
+  public String getName() {
+    return name;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  private String getHidden() {
+    return hidden;
+  }
+
+  private void setHidden(String hidden) {
+    this.hidden = hidden;
+  }
+
+  public TestEnumDescription getChoice() {
+    return choice;
+  }
+}

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/FooDescriptionEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/FooDescriptionEndpoint.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.server.spi.testing;
+
+import com.google.api.server.spi.config.Api;
+import com.google.api.server.spi.config.ApiMethod;
+import com.google.api.server.spi.config.ApiMethod.HttpMethod;
+import com.google.api.server.spi.config.Description;
+import com.google.api.server.spi.config.Named;
+import com.google.api.server.spi.response.CollectionResponse;
+
+@Api(
+    name = "foo",
+    version = "v1",
+    audiences = {"audience"},
+    title = "The Foo API",
+    description = "Just Foo Things")
+public class FooDescriptionEndpoint {
+  @ApiMethod(name = "foo.create", description = "create desc", path = "foos/{id}",
+      httpMethod = HttpMethod.PUT)
+  public FooDescription createFoo(@Named("id") @Description("id desc") String id, FooDescription foo) {
+    return null;
+  }
+  @ApiMethod(name = "foo.get", description = "get desc", path = "foos/{id}",
+      httpMethod = HttpMethod.GET)
+  public FooDescription getFoo(@Named("id") @Description("id desc") String id) {
+    return null;
+  }
+  @ApiMethod(name = "foo.update", description = "update desc", path = "foos/{id}",
+      httpMethod = HttpMethod.POST)
+  public FooDescription updateFoo(@Named("id") @Description("id desc") String id, FooDescription foo) {
+    return null;
+  }
+  @ApiMethod(name = "foo.delete", description = "delete desc", path = "foos/{id}",
+      httpMethod = HttpMethod.DELETE)
+  public FooDescription deleteFoo(@Named("id") @Description("id desc") String id) {
+    return null;
+  }
+  @ApiMethod(name = "foo.list", description = "list desc", path = "foos",
+      httpMethod = HttpMethod.GET)
+  public CollectionResponse<FooDescription> listFoos(@Named("n") Integer n) {
+    return null;
+  }
+  @ApiMethod(name = "toplevel", path = "foos", httpMethod = HttpMethod.POST)
+  public CollectionResponse<FooDescription> toplevel() {
+    return null;
+  }
+}

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/TestEnumDescription.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/TestEnumDescription.java
@@ -13,21 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.api.server.spi.config;
+package com.google.api.server.spi.testing;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import com.google.api.server.spi.config.Description;
 
-/**
- * Annotation to specify the description of an API parameter.
- */
-@Target({ElementType.PARAMETER, ElementType.FIELD})
-@Retention(RetentionPolicy.RUNTIME)
-public @interface Description {
-  /**
-   * The parameter description.
-   */
-  String value() default "";
+public enum TestEnumDescription {
+  @Description("description of value1")
+  VALUE1,
+  @Description("description of value2")
+  VALUE2
 }

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/TestEnumDescription.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/TestEnumDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2018 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/TestEnumDescription.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/TestEnumDescription.java
@@ -21,5 +21,7 @@ public enum TestEnumDescription {
   @Description("description of value1")
   VALUE1,
   @Description("description of value2")
-  VALUE2
+  VALUE2;
+
+  public String notAConstant;
 }


### PR DESCRIPTION
This PR allows to set a description on enum values in API method parameters, as allowed in the discovery format.
- The DiscoveryGenerator [already supported enum descriptions](https://github.com/cloudendpoints/endpoints-java/blob/master/endpoints-framework/src/main/java/com/google/api/server/spi/discovery/DiscoveryGenerator.java#L230).
- The OpenAPI format does not support descriptions on enum values ([yet](https://github.com/OAI/OpenAPI-Specification/issues/348)).

PS: we tried to implement description for enums in Swagger [here](https://github.com/AODocs/endpoints-java/tree/enum_description_in_swagger), as described in [Swagger documentation for enums](https://swagger.io/docs/specification/data-models/enums/), using the description field, but we preferred not to include it yet.