### PR TITLE
Handle properly Google's tokeninfo 503/backend error

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/auth/EndpointsAuthenticator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/auth/EndpointsAuthenticator.java
@@ -20,6 +20,7 @@ import com.google.api.server.spi.auth.common.User;
 import com.google.api.server.spi.config.Authenticator;
 import com.google.api.server.spi.config.Singleton;
 import com.google.api.server.spi.request.Attribute;
+import com.google.api.server.spi.response.ServiceUnavailableException;
 import com.google.common.annotations.VisibleForTesting;
 
 import javax.servlet.http.HttpServletRequest;
@@ -51,7 +52,7 @@ public class EndpointsAuthenticator implements Authenticator {
   }
 
   @Override
-  public User authenticate(HttpServletRequest request) {
+  public User authenticate(HttpServletRequest request) throws ServiceUnavailableException {
     Attribute attr = Attribute.from(request);
     User user = jwtAuthenticator.authenticate(request);
     if (user == null) {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/auth/GoogleAppEngineAuthenticator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/auth/GoogleAppEngineAuthenticator.java
@@ -22,6 +22,7 @@ import com.google.api.server.spi.config.Singleton;
 import com.google.api.server.spi.config.model.ApiMethodConfig;
 import com.google.api.server.spi.config.scope.AuthScopeExpression;
 import com.google.api.server.spi.request.Attribute;
+import com.google.api.server.spi.response.ServiceUnavailableException;
 import com.google.appengine.api.oauth.OAuthRequestException;
 import com.google.appengine.api.oauth.OAuthService;
 import com.google.appengine.api.oauth.OAuthServiceFactory;
@@ -56,7 +57,7 @@ class GoogleAppEngineAuthenticator implements Authenticator {
   }
 
   @VisibleForTesting
-  String getOAuth2ClientIdDev(String token) {
+  String getOAuth2ClientIdDev(String token) throws ServiceUnavailableException {
     GoogleAuth.TokenInfo tokenInfo = GoogleAuth.getTokenInfoRemote(token);
     return tokenInfo != null ? tokenInfo.clientId : null;
   }
@@ -68,7 +69,7 @@ class GoogleAppEngineAuthenticator implements Authenticator {
 
   @VisibleForTesting
   com.google.appengine.api.users.User getOAuth2User(HttpServletRequest request,
-      ApiMethodConfig config) {
+      ApiMethodConfig config) throws ServiceUnavailableException {
     String token = GoogleAuth.getAuthToken(request);
     if (!GoogleAuth.isOAuth2Token(token)) {
       return null;
@@ -114,7 +115,7 @@ class GoogleAppEngineAuthenticator implements Authenticator {
   }
 
   @Override
-  public User authenticate(HttpServletRequest request) {
+  public User authenticate(HttpServletRequest request) throws ServiceUnavailableException {
     Attribute attr = Attribute.from(request);
     if (!EnvUtil.isRunningOnAppEngine()) {
       return null;

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/auth/GoogleOAuth2Authenticator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/auth/GoogleOAuth2Authenticator.java
@@ -22,6 +22,7 @@ import com.google.api.server.spi.config.Authenticator;
 import com.google.api.server.spi.config.Singleton;
 import com.google.api.server.spi.config.model.ApiMethodConfig;
 import com.google.api.server.spi.request.Attribute;
+import com.google.api.server.spi.response.ServiceUnavailableException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 
@@ -39,7 +40,7 @@ public class GoogleOAuth2Authenticator implements Authenticator {
   private static final Logger logger = Logger.getLogger(GoogleOAuth2Authenticator.class.getName());
 
   @Override
-  public User authenticate(HttpServletRequest request) {
+  public User authenticate(HttpServletRequest request) throws ServiceUnavailableException {
     Attribute attr = Attribute.from(request);
     if (attr.isEnabled(Attribute.SKIP_TOKEN_AUTH)) {
       return null;
@@ -89,7 +90,7 @@ public class GoogleOAuth2Authenticator implements Authenticator {
   }
 
   @VisibleForTesting
-  TokenInfo getTokenInfoRemote(String token) {
+  TokenInfo getTokenInfoRemote(String token) throws ServiceUnavailableException {
     return GoogleAuth.getTokenInfoRemote(token);
   }
 }

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/auth/EndpointsAuthenticatorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/auth/EndpointsAuthenticatorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.server.spi.EnvUtil;
 import com.google.api.server.spi.auth.common.User;
 import com.google.api.server.spi.request.Attribute;
+import com.google.api.server.spi.response.ServiceUnavailableException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -53,13 +54,13 @@ public class EndpointsAuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticate_jwt() {
+  public void testAuthenticate_jwt() throws ServiceUnavailableException {
     when(jwtAuthenticator.authenticate(request)).thenReturn(USER);
     assertEquals(USER, authenticator.authenticate(request));
   }
 
   @Test
-  public void testAuthenticate_appEngine() {
+  public void testAuthenticate_appEngine() throws ServiceUnavailableException {
     when(jwtAuthenticator.authenticate(request)).thenReturn(null);
     when(appEngineAuthenticator.authenticate(request)).thenReturn(USER);
 
@@ -70,7 +71,7 @@ public class EndpointsAuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticate_oauth2NonAppEngine() {
+  public void testAuthenticate_oauth2NonAppEngine() throws ServiceUnavailableException {
     when(jwtAuthenticator.authenticate(request)).thenReturn(null);
     when(oauth2Authenticator.authenticate(request)).thenReturn(USER);
 
@@ -81,7 +82,7 @@ public class EndpointsAuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticate_oAuth2NotRequireAppEngineUser() {
+  public void testAuthenticate_oAuth2NotRequireAppEngineUser() throws ServiceUnavailableException {
     when(jwtAuthenticator.authenticate(request)).thenReturn(null);
     when(oauth2Authenticator.authenticate(request)).thenReturn(USER);
 

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/auth/GoogleAppEngineAuthenticatorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/auth/GoogleAppEngineAuthenticatorTest.java
@@ -24,6 +24,7 @@ import com.google.api.server.spi.auth.common.User;
 import com.google.api.server.spi.config.model.ApiMethodConfig;
 import com.google.api.server.spi.config.scope.AuthScopeExpressions;
 import com.google.api.server.spi.request.Attribute;
+import com.google.api.server.spi.response.ServiceUnavailableException;
 import com.google.appengine.api.oauth.OAuthRequestException;
 import com.google.appengine.api.oauth.OAuthService;
 import com.google.appengine.api.users.UserService;
@@ -87,7 +88,7 @@ public class GoogleAppEngineAuthenticatorTest {
   }
 
   @Test
-  public void testGetOAuth2UserNonOAuth2() {
+  public void testGetOAuth2UserNonOAuth2() throws ServiceUnavailableException {
     initializeRequest("Bearer badToken");
     assertNull(authenticator.getOAuth2User(request, config));
 
@@ -152,7 +153,7 @@ public class GoogleAppEngineAuthenticatorTest {
   }
 
   @Test
-  public void testGetOAuth2UserAppEngineDevClientIdNotAllowed() {
+  public void testGetOAuth2UserAppEngineDevClientIdNotAllowed() throws ServiceUnavailableException {
     System.setProperty(EnvUtil.ENV_APPENGINE_RUNTIME, "Developement");
     when(config.getScopeExpression()).thenReturn(AuthScopeExpressions.interpret(SCOPES));
     when(config.getClientIds()).thenReturn(ImmutableList.of("clientId2"));
@@ -160,19 +161,19 @@ public class GoogleAppEngineAuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticateNonAppEngine() {
+  public void testAuthenticateNonAppEngine() throws ServiceUnavailableException {
     System.clearProperty(EnvUtil.ENV_APPENGINE_RUNTIME);
     assertNull(authenticator.authenticate(request));
   }
 
   @Test
-  public void testAuthenticateSkipTokenAuth() {
+  public void testAuthenticateSkipTokenAuth() throws ServiceUnavailableException {
     attr.set(Attribute.SKIP_TOKEN_AUTH, true);
     assertNull(authenticator.authenticate(request));
   }
 
   @Test
-  public void testAuthenticateOAuth2Fail() {
+  public void testAuthenticateOAuth2Fail() throws ServiceUnavailableException {
     authenticator = new GoogleAppEngineAuthenticator(oauthService, userService) {
       @Override
       com.google.appengine.api.users.User getOAuth2User(HttpServletRequest request,
@@ -189,7 +190,7 @@ public class GoogleAppEngineAuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticateOAuth2() {
+  public void testAuthenticateOAuth2() throws ServiceUnavailableException {
     authenticator = new GoogleAppEngineAuthenticator(oauthService, userService) {
       @Override
       com.google.appengine.api.users.User getOAuth2User(HttpServletRequest request,
@@ -202,7 +203,7 @@ public class GoogleAppEngineAuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticateSkipTokenAuthCookieAuthFail() {
+  public void testAuthenticateSkipTokenAuthCookieAuthFail() throws ServiceUnavailableException {
     attr.set(Attribute.SKIP_TOKEN_AUTH, true);
     authenticator = new GoogleAppEngineAuthenticator(oauthService, userService) {
       @Override
@@ -215,7 +216,7 @@ public class GoogleAppEngineAuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticateSkipTokenAuthCookieAuth() {
+  public void testAuthenticateSkipTokenAuthCookieAuth() throws ServiceUnavailableException {
     attr.set(Attribute.SKIP_TOKEN_AUTH, true);
     authenticator = new GoogleAppEngineAuthenticator(oauthService, userService) {
       @Override
@@ -229,7 +230,7 @@ public class GoogleAppEngineAuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticateOAuth2CookieAuthBothFail() {
+  public void testAuthenticateOAuth2CookieAuthBothFail() throws ServiceUnavailableException {
     authenticator = new GoogleAppEngineAuthenticator(oauthService, userService) {
       @Override
       com.google.appengine.api.users.User getOAuth2User(HttpServletRequest request,
@@ -247,7 +248,7 @@ public class GoogleAppEngineAuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticateOAuth2FailCookieAuth() {
+  public void testAuthenticateOAuth2FailCookieAuth() throws ServiceUnavailableException {
     authenticator = new GoogleAppEngineAuthenticator(oauthService, userService) {
       @Override
       com.google.appengine.api.users.User getOAuth2User(HttpServletRequest request,

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/auth/GoogleOAuth2AuthenticatorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/auth/GoogleOAuth2AuthenticatorTest.java
@@ -24,6 +24,7 @@ import com.google.api.server.spi.auth.common.User;
 import com.google.api.server.spi.config.model.ApiMethodConfig;
 import com.google.api.server.spi.config.scope.AuthScopeExpressions;
 import com.google.api.server.spi.request.Attribute;
+import com.google.api.server.spi.response.ServiceUnavailableException;
 import com.google.common.collect.ImmutableList;
 
 import org.junit.Before;
@@ -65,38 +66,38 @@ public class GoogleOAuth2AuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticate_skipTokenAuth() {
+  public void testAuthenticate_skipTokenAuth() throws ServiceUnavailableException {
     attr.set(Attribute.SKIP_TOKEN_AUTH, true);
     assertNull(authenticator.authenticate(request));
   }
 
   @Test
-  public void testAuthenticate_notOAuth2() {
+  public void testAuthenticate_notOAuth2() throws ServiceUnavailableException {
     initializeRequest("Bearer badToken");
     assertNull(authenticator.authenticate(request));
   }
 
   @Test
-  public void testAuthenticate_nullTokenInfo() {
+  public void testAuthenticate_nullTokenInfo() throws ServiceUnavailableException {
     authenticator = createAuthenticator(null, null, null, null);
     assertNull(authenticator.authenticate(request));
   }
 
   @Test
-  public void testAuthenticate_scopeNotAllowed() {
+  public void testAuthenticate_scopeNotAllowed() throws ServiceUnavailableException {
     when(config.getScopeExpression()).thenReturn(AuthScopeExpressions.interpret("scope3"));
     assertNull(authenticator.authenticate(request));
   }
 
   @Test
-  public void testAuthenticate_clientIdNotAllowed() {
+  public void testAuthenticate_clientIdNotAllowed() throws ServiceUnavailableException {
     when(config.getScopeExpression()).thenReturn(AuthScopeExpressions.interpret("scope1"));
     when(config.getClientIds()).thenReturn(ImmutableList.of("clientId2"));
     assertNull(authenticator.authenticate(request));
   }
 
   @Test
-  public void testAuthenticate_skipClientIdCheck() {
+  public void testAuthenticate_skipClientIdCheck() throws ServiceUnavailableException {
     request.removeAttribute(Attribute.ENABLE_CLIENT_ID_WHITELIST);
     when(config.getScopeExpression()).thenReturn(AuthScopeExpressions.interpret("scope1"));
     when(config.getClientIds()).thenReturn(ImmutableList.of("clientId2"));
@@ -106,7 +107,7 @@ public class GoogleOAuth2AuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticate() {
+  public void testAuthenticate() throws ServiceUnavailableException {
     when(config.getScopeExpression()).thenReturn(AuthScopeExpressions.interpret("scope1"));
     when(config.getClientIds()).thenReturn(ImmutableList.of(CLIENT_ID));
     User user = authenticator.authenticate(request);
@@ -115,7 +116,7 @@ public class GoogleOAuth2AuthenticatorTest {
   }
 
   @Test
-  public void testAuthenticate_appEngineUser() {
+  public void testAuthenticate_appEngineUser() throws ServiceUnavailableException {
     attr.set(Attribute.REQUIRE_APPENGINE_USER, true);
     when(config.getScopeExpression()).thenReturn(AuthScopeExpressions.interpret("scope1"));
     when(config.getClientIds()).thenReturn(ImmutableList.of(CLIENT_ID));


### PR DESCRIPTION
We are using Cloud Endpoints to serve a large scale API (millions of API requests per day).
We measure a low but significant amount of transient "503/backend error" when validating OAuth2 requests with GoogleAuth#getTokenInfoRemote, that translates into a "401/UnauthorizedException" for the API clients => this is not what one would expect for a transient exception.

This pull request introduce two main changes:
- It performs a single, immediate retry on https://www.googleapis.com/oauth2/v2/tokeninfo?access_token=XXX  for IOExceptions and 5xx responses
- If the retry on IOException or 5xx fails, a "503/ServiceUnavailableException" is returned to API client, instead of a "401/UnauthorizedException"