### PR TITLE
quietly allow underscores in API names

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/validation/ApiConfigValidator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/validation/ApiConfigValidator.java
@@ -56,8 +56,10 @@ import java.util.regex.Pattern;
  */
 public class ApiConfigValidator {
   private static final Logger log = Logger.getLogger(ApiConfigValidator.class.getName());
+  // The underscore is allowed in the API name because of very old legacy reasons, despite the
+  // annotation documentation stating otherwise.
   private static final Pattern API_NAME_PATTERN = Pattern.compile(
-      "^[a-z]+[A-Za-z0-9]*$");
+      "^[a-z]+[A-Za-z0-9_]*$");
 
   private static final Pattern API_METHOD_NAME_PATTERN = Pattern.compile(
       "^\\w+(\\.\\w+)*$");


### PR DESCRIPTION
The official documentation for a long time has disallowed underscores
in API names, so I'm leaving it as such. However, for extremely old
users of the old frameworks, this limitation was not in
place. Therefore, I'm removing it from the API validation, but leaving
the @Api documentation in order to not encourage the style.