### PR TITLE
check non-nullness of required parameters

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/ServletRequestParamReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/ServletRequestParamReader.java
@@ -178,7 +178,7 @@ public class ServletRequestParamReader extends AbstractParamReader {
           logger.log(Level.FINE, "deserialize: {0} {1} injected into unnamed param[{2}]",
               new Object[]{clazz, params[i], i});
         } else if (StandardParameters.isStandardParamName(name)) {
-            params[i] = getStandardParamValue(node, name);
+          params[i] = getStandardParamValue(node, name);
         } else {
           JsonNode nodeValue = node.get(name);
           if (nodeValue == null) {

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/request/RestServletRequestParamReaderTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/request/RestServletRequestParamReaderTest.java
@@ -27,6 +27,7 @@ import com.google.api.server.spi.config.ApiMethod;
 import com.google.api.server.spi.config.ApiMethod.HttpMethod;
 import com.google.api.server.spi.config.DefaultValue;
 import com.google.api.server.spi.config.Named;
+import com.google.api.server.spi.config.Nullable;
 import com.google.api.server.spi.config.annotationreader.ApiConfigAnnotationReader;
 import com.google.api.server.spi.config.model.ApiConfig;
 import com.google.api.server.spi.config.model.ApiMethodConfig;
@@ -229,7 +230,9 @@ public class RestServletRequestParamReaderTest {
   @Api
   public static class TestApi {
     @ApiMethod(name = "test", httpMethod = HttpMethod.GET, path = "test/{path}")
-    public void test(@Named("path") long path, @Named("dates") List<SimpleDate> dates,
+    public void test(
+        @Nullable @Named("path") long path,
+        @Nullable @Named("dates") List<SimpleDate> dates,
         @Named("defaultvalue") @DefaultValue("2015-01-01") SimpleDate defaultValue,
         TestResource resource) {
     }


### PR DESCRIPTION
@Named parameters that don't have @Nullable parameters are deemed
required. Endpoints v2 lost this request validation, but this change
adds it back in. Previously, the framework would assume the validation
was done.