### PR TITLE
 Replaced printStackTrace() with JUL

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/RestServletRequestParamReader.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/RestServletRequestParamReader.java
@@ -135,7 +135,7 @@ public class RestServletRequestParamReader extends ServletRequestParamReader {
       return deserializeParams(body);
     } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException
         | IOException e) {
-      e.printStackTrace();
+      logger.log(Level.INFO, "Unable to read request parameter(s):", e);
       throw new BadRequestException(e);
     }
   }


### PR DESCRIPTION
If an enum was misspelled, this printStrackTrace spammed the logs with WARNING lines.