### PR TITLE
Improve Swagger schema compatibility with Cloud Endpoints Portal

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/swagger/SwaggerGenerator.java
@@ -248,7 +248,9 @@ public class SwaggerGenerator {
     List<Schema> schemas = genCtx.schemata.getAllSchemaForApi(apiKey);
     if (!schemas.isEmpty()) {
       for (Schema schema : schemas) {
-        swagger.addDefinition(schema.name(), convertToSwaggerSchema(schema));
+        if (schema.enumValues().isEmpty()) {
+          swagger.addDefinition(schema.name(), convertToSwaggerSchema(schema));
+        }
       }
     }
   }
@@ -404,17 +406,13 @@ public class SwaggerGenerator {
   }
 
   private Model convertToSwaggerSchema(Schema schema) {
-    ModelImpl docSchema = new ModelImpl();
+    ModelImpl docSchema = new ModelImpl().type("object");
     Map<String, Property> fields = Maps.newLinkedHashMap();
     if (!schema.fields().isEmpty()) {
       for (Field f : schema.fields().values()) {
         fields.put(f.name(), convertToSwaggerProperty(f));
       }
       docSchema.setProperties(fields);
-    }
-    if (!schema.enumValues().isEmpty()) {
-      docSchema.setType("string");
-      docSchema._enum(schema.enumValues());
     }
     return docSchema;
   }
@@ -429,10 +427,12 @@ public class SwaggerGenerator {
         //cannot happen, as Property subclasses are guaranteed to have a default constructor
       }
     } else {
-      if (f.type() == FieldType.OBJECT || f.type() == FieldType.ENUM) {
+      if (f.type() == FieldType.OBJECT) {
         p = new RefProperty(f.schemaReference().get().name());
       } else if (f.type() == FieldType.ARRAY) {
         p = new ArrayProperty(convertToSwaggerProperty(f.arrayItemSchema()));
+      } else if (f.type() == FieldType.ENUM) {
+        p = new StringProperty()._enum(getEnumValues(f.schemaReference().type()));
       }
     }
     if (p == null) {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_common_path_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_common_path_endpoint.swagger
@@ -44,6 +44,7 @@
   },
   "definitions": {
     "Foo": {
+      "type": "object",
       "properties": {
         "name": {
           "type": "string"

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
@@ -55,6 +55,7 @@
   },
   "definitions": {
     "Foo": {
+      "type": "object",
       "properties": {
         "name": {
           "type": "string"

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/array_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/array_endpoint.swagger
@@ -201,6 +201,7 @@
   },
   "definitions": {
     "CollectionResponse_Integer": {
+      "type": "object",
       "properties": {
         "items": {
           "type": "array",
@@ -215,6 +216,7 @@
       }
     },
     "CollectionResponse_Foo": {
+      "type": "object",
       "properties": {
         "items": {
           "type": "array",
@@ -228,6 +230,7 @@
       }
     },
     "Foo": {
+      "type": "object",
       "properties": {
         "name": {
           "type": "string"
@@ -239,6 +242,7 @@
       }
     },
     "FooCollectionCollection": {
+      "type": "object",
       "properties": {
         "items": {
           "type": "array",
@@ -251,7 +255,19 @@
         }
       }
     },
+    "ListContainer": {
+      "type": "object",
+      "properties": {
+        "strings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "Baz": {
+      "type": "object",
       "properties": {
         "foo": {
           "$ref": "#/definitions/Foo"
@@ -264,17 +280,8 @@
         }
       }
     },
-    "ListContainer": {
-      "properties": {
-        "strings": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "CollectionResponse_FooCollection": {
+      "type": "object",
       "properties": {
         "items": {
           "type": "array",
@@ -291,6 +298,7 @@
       }
     },
     "ArrayEndpoint": {
+      "type": "object",
       "properties": {
         "allArrayedFoos": {
           "type": "array",
@@ -360,6 +368,7 @@
       }
     },
     "IntegerCollection": {
+      "type": "object",
       "properties": {
         "items": {
           "type": "array",
@@ -370,17 +379,8 @@
         }
       }
     },
-    "FooCollection": {
-      "properties": {
-        "items": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Foo"
-          }
-        }
-      }
-    },
     "CollectionResponse_FooCollectionCollection": {
+      "type": "object",
       "properties": {
         "items": {
           "type": "array",
@@ -396,6 +396,17 @@
         },
         "nextPageToken": {
           "type": "string"
+        }
+      }
+    },
+    "FooCollection": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Foo"
+          }
         }
       }
     }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/enum_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/enum_endpoint.swagger
@@ -44,18 +44,16 @@
   },
   "definitions": {
     "EnumValue": {
+      "type": "object",
       "properties": {
         "value": {
-          "$ref": "#/definitions/TestEnum"
+          "type": "string",
+          "enum": [
+            "VALUE1",
+            "VALUE2"
+          ]
         }
       }
-    },
-    "TestEnum": {
-      "type": "string",
-      "enum": [
-        "VALUE1",
-        "VALUE2"
-      ]
     }
   }
 }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
@@ -222,6 +222,7 @@
   },
   "definitions": {
     "CollectionResponse_Foo": {
+      "type": "object",
       "properties": {
         "items": {
           "type": "array",
@@ -235,6 +236,7 @@
       }
     },
     "Foo": {
+      "type": "object",
       "properties": {
         "name": {
           "type": "string"

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
@@ -222,6 +222,7 @@
   },
   "definitions": {
     "CollectionResponse_Foo": {
+      "type": "object",
       "properties": {
         "items": {
           "type": "array",
@@ -235,6 +236,7 @@
       }
     },
     "Foo": {
+      "type": "object",
       "properties": {
         "name": {
           "type": "string"

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
@@ -222,6 +222,7 @@
   },
   "definitions": {
     "CollectionResponse_Foo": {
+      "type": "object",
       "properties": {
         "items": {
           "type": "array",
@@ -235,6 +236,7 @@
       }
     },
     "Foo": {
+      "type": "object",
       "properties": {
         "name": {
           "type": "string"

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
@@ -222,6 +222,7 @@
   },
   "definitions": {
     "CollectionResponse_Foo": {
+      "type": "object",
       "properties": {
         "items": {
           "type": "array",
@@ -235,6 +236,7 @@
       }
     },
     "Foo": {
+      "type": "object",
       "properties": {
         "name": {
           "type": "string"

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_with_description_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_with_description_endpoint.swagger
@@ -233,6 +233,7 @@
   },
   "definitions": {
     "CollectionResponse_FooDescription": {
+      "type": "object",
       "properties": {
         "items": {
           "type": "array",
@@ -245,22 +246,20 @@
         }
       }
     },
-    "TestEnumDescription": {
-      "type": "string",
-      "enum": [
-        "VALUE1",
-        "VALUE2"
-      ]
-    },
     "FooDescription": {
+      "type": "object",
       "properties": {
         "choice": {
+          "type": "string",
           "description": "description of choice",
-          "$ref": "#/definitions/TestEnumDescription"
+          "enum": [
+            "VALUE1",
+            "VALUE2"
+          ]
         },
         "name": {
-          "description": "description of name",
-          "type": "string"
+          "type": "string",
+          "description": "description of name"
         },
         "value": {
           "type": "integer",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/limit_metrics_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/limit_metrics_endpoint.swagger
@@ -55,6 +55,7 @@
   },
   "definitions": {
     "Foo": {
+      "type": "object",
       "properties": {
         "name": {
           "type": "string"
@@ -87,8 +88,8 @@
           "values": {
             "STANDARD": 100
           },
-          "displayName": "Read requests",
-          "unit": "1/min/{project}"
+          "unit": "1/min/{project}",
+          "displayName": "Read requests"
         },
         {
           "name": "write",


### PR DESCRIPTION
This change adds the missing "type": "object" field in resource schema, to prevent resources to be displayed as "any" schema definition in Cloud Endpoints Portal.

Also, it removes enums from resources, as they can't be used neither as body or response, and Endpoints Portal does not display the possible values anyway. 
Instead, it inlines the enum definitions each time they are used.