### PR TITLE
Enrich and expose internal methods related to authentication

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/PeerAuth.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/PeerAuth.java
@@ -70,6 +70,11 @@ public class PeerAuth {
         }
       };
 
+  public static PeerAuthenticator instantiatePeerAuthenticator(Class<? extends PeerAuthenticator> clazz) {
+    return INSTANTIATE_PEER_AUTHENTICATOR.apply(clazz);
+  }
+
+
   private final HttpServletRequest request;
   private final Attribute attr;
   private final ApiMethodConfig config;
@@ -78,7 +83,7 @@ public class PeerAuth {
   PeerAuth(HttpServletRequest request) {
     this.request = request;
     attr = Attribute.from(request);
-    config = (ApiMethodConfig) attr.get(Attribute.API_METHOD_CONFIG);
+    config = attr.get(Attribute.API_METHOD_CONFIG);
   }
 
   static PeerAuth from(HttpServletRequest request) {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/auth/GoogleAppEngineAuthenticator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/auth/GoogleAppEngineAuthenticator.java
@@ -122,7 +122,7 @@ class GoogleAppEngineAuthenticator implements Authenticator {
     }
 
     com.google.appengine.api.users.User appEngineUser = null;
-    ApiMethodConfig config = (ApiMethodConfig) attr.get(Attribute.API_METHOD_CONFIG);
+    ApiMethodConfig config = attr.get(Attribute.API_METHOD_CONFIG);
     if (!attr.isEnabled(Attribute.SKIP_TOKEN_AUTH)) {
       appEngineUser = getOAuth2User(request, config);
     }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/auth/GoogleJwtAuthenticator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/auth/GoogleJwtAuthenticator.java
@@ -79,10 +79,12 @@ public class GoogleJwtAuthenticator implements Authenticator {
       return null;
     }
 
+    attr.set(Attribute.ID_TOKEN, idToken);
+
     String clientId = idToken.getPayload().getAuthorizedParty();
     String audience = (String) idToken.getPayload().getAudience();
 
-    ApiMethodConfig config = (ApiMethodConfig) attr.get(Attribute.API_METHOD_CONFIG);
+    ApiMethodConfig config = attr.get(Attribute.API_METHOD_CONFIG);
 
     // Check client id.
     if ((attr.isEnabled(Attribute.ENABLE_CLIENT_ID_WHITELIST)

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/auth/GoogleOAuth2Authenticator.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/auth/GoogleOAuth2Authenticator.java
@@ -56,6 +56,8 @@ public class GoogleOAuth2Authenticator implements Authenticator {
       return null;
     }
 
+    attr.set(Attribute.TOKEN_INFO, tokenInfo);
+
     ApiMethodConfig config = (ApiMethodConfig) request.getAttribute(Attribute.API_METHOD_CONFIG);
 
     // Check scopes.

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/Singleton.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/Singleton.java
@@ -15,10 +15,20 @@
  */
 package com.google.api.server.spi.config;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Annotation used with Authenticator and PeerAuthenticator to denote only one instance will be
@@ -28,4 +38,53 @@ import java.lang.annotation.Target;
 @Target(value = ElementType.TYPE)
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface Singleton {
+
+  /**
+   * Instantiates instances of A, honoring the @{@link Singleton} contract.
+   * Return a default instance when passed null values.
+   */
+  class Instantiator<A> {
+
+    private static final Logger logger = Logger.getLogger(Instantiator.class.getName());
+
+    private volatile Map<Class<? extends A>, A> instances = new HashMap<>();
+
+    private final A defaultValue;
+
+    private final Function<Class<? extends A>, A> instantiator
+        = new Function<Class<? extends A>, A>() {
+      @Override
+      public A apply(Class<? extends A> clazz) {
+        try {
+          if (clazz.getAnnotation(Singleton.class) != null) {
+            if (!instances.containsKey(clazz)) {
+              instances.put(clazz, clazz.newInstance());
+            }
+            return instances.get(clazz);
+          } else {
+            return clazz.newInstance();
+          }
+        } catch (IllegalAccessException | InstantiationException e) {
+          logger.log(Level.WARNING, "Could not instantiate: " + clazz.getName());
+          return null;
+        }
+      }
+    };
+
+    public Instantiator(A defaultValue) {
+      this.defaultValue = defaultValue;
+    }
+
+    public A getInstanceOrDefault(Class<? extends A> clazz) {
+      return clazz == null ? defaultValue : instantiator.apply(clazz);
+    }
+
+    public Iterable<A> getInstancesOrDefault(List<Class<? extends A>> classes) {
+      return classes == null ? ImmutableList.of(defaultValue)
+          : Iterables.filter(Iterables.transform(classes, instantiator),
+              Predicates.notNull());
+    }
+
+  }
+
 }

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/Attribute.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/Attribute.java
@@ -26,15 +26,54 @@ import javax.servlet.http.HttpServletRequest;
  * Defines attribute constants passed in Request.
  */
 public class Attribute {
+  /**
+   * A {@link com.google.appengine.api.users.User} with the currently authenticated App Engine user.
+   *
+   */
   public static final String AUTHENTICATED_APPENGINE_USER =
       "endpoints:Authenticated-AppEngine-User";
+  /**
+   * A {@link com.google.api.server.spi.config.model.ApiMethodConfig} with the current API method's
+   * configuration.
+   */
   public static final String API_METHOD_CONFIG = "endpoints:Api-Method-Config";
+  /**
+   * A {@link Boolean} indicating if client id whitelist should be checked.
+   */
   public static final String ENABLE_CLIENT_ID_WHITELIST =
       "endpoints:Enable-Client-Id-Whitelist";
+  /**
+   * @deprecated
+   */
   public static final String RESTRICT_SERVLET = "endpoints:Restrict-Servlet";
+  /**
+   * A {@link Boolean} indicating if the App Engine user should be populated.
+   */
   public static final String REQUIRE_APPENGINE_USER = "endpoints:Require-AppEngine-User";
+  /**
+   * A {@link Boolean} indicating if token-based authentications (OAuth2 and JWT) should be skipped.
+   */
   public static final String SKIP_TOKEN_AUTH = "endpoints:Skip-Token-Auth";
+  /**
+   * A {@link String} with the current request's auth token.
+   */
   public static final String AUTH_TOKEN = "endpoints:Auth-Token";
+  /**
+   * If set, contains a cached OAuth2 {@link com.google.api.server.spi.auth.GoogleAuth.TokenInfo}
+   * corresponding to the String token in the {@link Attribute#AUTH_TOKEN} {@value AUTH_TOKEN}
+   * attribute.
+   * The authentication from {@link com.google.api.server.spi.auth.GoogleOAuth2Authenticator} might
+   * have failed anyway because of unauthorized client id or scopes.
+   */
+  public static final String TOKEN_INFO = "endpoints:Token-Info";
+  /**
+   * If set, contains a cached instance of a parsed and valid JWT
+   * {@link com.google.api.client.googleapis.auth.oauth2.GoogleIdToken} corresponding to the String
+   * token in the {@link Attribute#AUTH_TOKEN} {@value AUTH_TOKEN} attribute.
+   * The authentication from {@link com.google.api.server.spi.auth.GoogleJwtAuthenticator} might
+   * have failed anyway because of unauthorized client id or audience.
+   */
+  public static final String ID_TOKEN = "endpoints:Id-Token";
 
   private final HttpServletRequest request;
 
@@ -47,8 +86,8 @@ public class Attribute {
     return new Attribute(request);
   }
 
-  public Object get(String attr) {
-    return request.getAttribute(attr);
+  public <T> T get(String attr) {
+    return (T) request.getAttribute(attr);
   }
 
   public void set(String attr, Object value) {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/request/Auth.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/request/Auth.java
@@ -67,6 +67,10 @@ public class Auth {
         }
       };
 
+  public static Authenticator instantiateAuthenticator(Class<? extends Authenticator> clazz) {
+    return INSTANTIATE_AUTHENTICATOR.apply(clazz);
+  }
+
   private final HttpServletRequest request;
   private final Attribute attr;
   private final ApiMethodConfig config;
@@ -75,7 +79,7 @@ public class Auth {
   Auth(HttpServletRequest request) {
     this.request = request;
     attr = Attribute.from(request);
-    config = (ApiMethodConfig) attr.get(Attribute.API_METHOD_CONFIG);
+    config = attr.get(Attribute.API_METHOD_CONFIG);
   }
 
   static Auth from(HttpServletRequest request) {
@@ -122,7 +126,7 @@ public class Auth {
       return null;
     }
     com.google.appengine.api.users.User appEngineUser =
-        (com.google.appengine.api.users.User) attr.get(Attribute.AUTHENTICATED_APPENGINE_USER);
+        attr.get(Attribute.AUTHENTICATED_APPENGINE_USER);
     if (appEngineUser != null) {
       return appEngineUser;
     } else {

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/auth/GoogleOAuth2AuthenticatorTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/auth/GoogleOAuth2AuthenticatorTest.java
@@ -16,6 +16,7 @@
 package com.google.api.server.spi.auth;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
@@ -69,24 +70,28 @@ public class GoogleOAuth2AuthenticatorTest {
   public void testAuthenticate_skipTokenAuth() throws ServiceUnavailableException {
     attr.set(Attribute.SKIP_TOKEN_AUTH, true);
     assertNull(authenticator.authenticate(request));
+    assertNull(attr.get(Attribute.TOKEN_INFO));
   }
 
   @Test
   public void testAuthenticate_notOAuth2() throws ServiceUnavailableException {
     initializeRequest("Bearer badToken");
     assertNull(authenticator.authenticate(request));
+    assertNull(attr.get(Attribute.TOKEN_INFO));
   }
 
   @Test
   public void testAuthenticate_nullTokenInfo() throws ServiceUnavailableException {
     authenticator = createAuthenticator(null, null, null, null);
     assertNull(authenticator.authenticate(request));
+    assertNull(attr.get(Attribute.TOKEN_INFO));
   }
 
   @Test
   public void testAuthenticate_scopeNotAllowed() throws ServiceUnavailableException {
     when(config.getScopeExpression()).thenReturn(AuthScopeExpressions.interpret("scope3"));
     assertNull(authenticator.authenticate(request));
+    assertNotNull(attr.get(Attribute.TOKEN_INFO));
   }
 
   @Test
@@ -94,6 +99,7 @@ public class GoogleOAuth2AuthenticatorTest {
     when(config.getScopeExpression()).thenReturn(AuthScopeExpressions.interpret("scope1"));
     when(config.getClientIds()).thenReturn(ImmutableList.of("clientId2"));
     assertNull(authenticator.authenticate(request));
+    assertNotNull(attr.get(Attribute.TOKEN_INFO));
   }
 
   @Test
@@ -104,6 +110,7 @@ public class GoogleOAuth2AuthenticatorTest {
     User user = authenticator.authenticate(request);
     assertEquals(EMAIL, user.getEmail());
     assertEquals(USER_ID, user.getId());
+    assertNotNull(attr.get(Attribute.TOKEN_INFO));
   }
 
   @Test
@@ -113,6 +120,10 @@ public class GoogleOAuth2AuthenticatorTest {
     User user = authenticator.authenticate(request);
     assertEquals(EMAIL, user.getEmail());
     assertEquals(USER_ID, user.getId());
+    final TokenInfo tokenInfo = attr.get(Attribute.TOKEN_INFO);
+    assertNotNull(tokenInfo);
+    assertEquals(EMAIL, tokenInfo.email);
+    assertEquals(USER_ID, tokenInfo.userId);
   }
 
   @Test


### PR DESCRIPTION
- add missing TokenInfo fields, and expose GoogleAuth.getTokenInfoRemote
- Store validated TokenInfo or GoogleIdToken in request attribute, for custom Authenticators usage
- Expose Auth/PeerAuth.instantiate(Peer)Authenticator to enforce @Singleton contract
- Add Javadoc on request Attribute constants

The main goal of these changes is to allow implementing custom Authenticators more easily and efficiently, such as what is implement in [this project](https://github.com/AODocs/endpoints-authenticators).
It does not change any of the existing behavior.