### PR TITLE
Expose EndpointsServlet internals to allow customizing JSON serialization

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/EndpointsServlet.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/EndpointsServlet.java
@@ -59,6 +59,14 @@ public class EndpointsServlet extends HttpServlet {
     this.corsHandler = new CorsHandler();
   }
 
+  protected ServletInitializationParameters getInitParameters() {
+    return initParameters;
+  }
+
+  protected SystemService getSystemService() {
+    return systemService;
+  }
+
   @Override
   public void service(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String method = getRequestMethod(request);
@@ -99,7 +107,8 @@ public class EndpointsServlet extends HttpServlet {
       MethodConfigMap methods = apiConfig.getApiClassConfig().getMethods();
       for (Entry<EndpointMethod, ApiMethodConfig> methodEntry : methods.entrySet()) {
         if (!methodEntry.getValue().isIgnored()) {
-          handlersBuilder.add(createEndpointsMethodHandler(apiConfig, methodEntry));
+          handlersBuilder.add(createEndpointsMethodHandler(methodEntry.getKey(),
+              methodEntry.getValue()));
         }
       }
     }
@@ -132,10 +141,10 @@ public class EndpointsServlet extends HttpServlet {
     }
   }
 
-  protected EndpointsMethodHandler createEndpointsMethodHandler(ApiConfig apiConfig,
-      Entry<EndpointMethod, ApiMethodConfig> methodEntry) {
-    return new EndpointsMethodHandler(initParameters, getServletContext(), methodEntry.getKey(),
-        apiConfig, methodEntry.getValue(), systemService);
+  protected EndpointsMethodHandler createEndpointsMethodHandler(EndpointMethod method,
+      ApiMethodConfig methodConfig) {
+    return new EndpointsMethodHandler(initParameters, getServletContext(), method,
+        methodConfig, systemService);
   }
 
   /**

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/response/ServletResponseResultWriter.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/response/ServletResponseResultWriter.java
@@ -33,10 +33,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
-import java.io.BufferedOutputStream;
-import java.io.BufferedWriter;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -44,7 +41,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 
 /**
@@ -95,8 +91,18 @@ public class ServletResponseResultWriter implements ResultWriter {
     if (prettyPrint) {
       objectWriter = objectWriter.with(new EndpointsPrettyPrinter());
     }
-    this.objectWriter = objectWriter;
+    this.objectWriter = configureWriter(objectWriter);
     this.addContentLength = addContentLength;
+  }
+
+  /**
+   * Override to add additional behavior, like partial response, etc.
+   *
+   * @param objectWriter the standard object writer
+   * @return a configured writer (might be wrapped)
+   */
+  protected ObjectWriter configureWriter(ObjectWriter objectWriter) {
+    return objectWriter;
   }
 
   @Override

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/handlers/EndpointsMethodHandlerTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/handlers/EndpointsMethodHandlerTest.java
@@ -108,8 +108,7 @@ public class EndpointsMethodHandlerTest {
         .build();
     TestMethodHandler handler = new TestMethodHandler(
         ServletInitializationParameters.builder().build(), method,
-        apiConfig, methodConfig, systemService, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-        RESOURCE);
+        methodConfig, systemService, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, RESOURCE);
     handler.getRestHandler().handle(context);
   }
 
@@ -120,8 +119,8 @@ public class EndpointsMethodHandlerTest {
         apiConfig.getApiClassConfig());
     methodConfig.setPath("/root");
     TestMethodHandler handler = new TestMethodHandler(
-        ServletInitializationParameters.builder().build(), method, apiConfig, methodConfig,
-        systemService, 200);
+        ServletInitializationParameters.builder().build(), method, methodConfig, systemService,
+        200);
     assertThat(handler.getRestPath()).isEqualTo("root");
   }
 
@@ -131,7 +130,7 @@ public class EndpointsMethodHandlerTest {
     ApiMethodConfig methodConfig = new ApiMethodConfig(method, typeLoader,
         apiConfig.getApiClassConfig());
     return new TestMethodHandler(ServletInitializationParameters.builder().build(), method,
-        apiConfig, methodConfig, systemService, expectedResponse, params);
+        methodConfig, systemService, expectedResponse, params);
   }
 
   private static class TestMethodHandler extends EndpointsMethodHandler {
@@ -140,12 +139,11 @@ public class EndpointsMethodHandlerTest {
     public TestMethodHandler(
         ServletInitializationParameters initParameters,
         EndpointMethod endpointMethod,
-        ApiConfig apiConfig,
         ApiMethodConfig methodConfig,
         SystemService systemService,
         Object expectedResult,
         Object... params) {
-      super(initParameters, null /* servletContext */, endpointMethod, apiConfig, methodConfig,
+      super(initParameters, null /* servletContext */, endpointMethod, methodConfig,
           systemService);
       this.params = params;
       this.expectedResult = expectedResult;


### PR DESCRIPTION
The goal of these changes is to allow customization of the JSON serialization process of API responses, by subclassing EndpointsServlet, EndpointsMethodHandler and ServletResponseResultWriter.

An example of such a customization is available in [this project](https://github.com/AODocs/endpoints-partialresponse/).
[PartialResponseEndpointsServlet](https://github.com/AODocs/endpoints-partialresponse/blob/master/src/main/java/com/aodocs/partialresponse/servlet/PartialResponseEndpointsServlet.java) provides a (hopefully) compatible implementation of the partial response feature that was dropped in Endpoints v2 (see #75).
It has some with additional goodies such as eager "fields" validation (Google APIs seem to validate it after executing backend methods), and JSON Pointer support.