### PR TITLE
Improve Swagger generation

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/model/SchemaRepository.java
@@ -58,7 +58,8 @@ public class SchemaRepository {
   static final String MAP_UNUSED_MSG = "unused for map values";
 
   private final Multimap<ApiKey, Schema> schemaByApiKeys = LinkedHashMultimap.create();
-  private final Map<ApiSerializationConfig, Map<TypeToken<?>, Schema>> types = Maps.newHashMap();
+  private final Map<ApiSerializationConfig, Map<TypeToken<?>, Schema>> types 
+      = Maps.newLinkedHashMap();
   private final ResourceSchemaProvider resourceSchemaProvider = new JacksonResourceSchemaProvider();
 
   private final TypeLoader typeLoader;
@@ -102,7 +103,7 @@ public class SchemaRepository {
   /**
    * Gets all schema for an API key.
    */
-  public List<Schema> getAllSchemaForApi(ApiKey apiKey) {
+  public ImmutableList<Schema> getAllSchemaForApi(ApiKey apiKey) {
     return ImmutableList.copyOf(schemaByApiKeys.get(apiKey.withoutRoot()));
   }
 
@@ -115,7 +116,7 @@ public class SchemaRepository {
   private Map<TypeToken<?>, Schema> getAllTypesForConfig(ApiConfig config) {
     Map<TypeToken<?>, Schema> typesForConfig = types.get(config.getSerializationConfig());
     if (typesForConfig == null) {
-      typesForConfig = Maps.newHashMap();
+      typesForConfig = Maps.newLinkedHashMap();
       types.put(config.getSerializationConfig(), typesForConfig);
     }
     return typesForConfig;

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/absolute_path_endpoint.swagger
@@ -18,7 +18,7 @@
   "paths": {
     "/absolutepath/v1/create": {
       "post": {
-        "operationId": "AbsolutepathCreateFoo",
+        "operationId": "AbsolutepathV1CreateFoo",
         "parameters": [],
         "responses": {
           "200": {
@@ -32,7 +32,7 @@
     },
     "/absolutepathmethod/v1": {
       "post": {
-        "operationId": "AbsolutepathAbsolutePath",
+        "operationId": "AbsolutepathV1AbsolutePath",
         "parameters": [],
         "responses": {
           "200": {
@@ -43,7 +43,7 @@
     },
     "/absolutepathmethod2/v1": {
       "post": {
-        "operationId": "AbsolutepathAbsolutePath2",
+        "operationId": "AbsolutepathV1AbsolutePath2",
         "parameters": [],
         "responses": {
           "200": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/api_keys.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/api_keys.swagger
@@ -18,7 +18,7 @@
   "paths": {
     "/apikeys/v1/apiKeyWithAuth": {
       "post": {
-        "operationId": "ApikeysApiKeyWithAuth",
+        "operationId": "ApikeysV1ApiKeyWithAuth",
         "parameters": [],
         "responses": {
           "200": {
@@ -35,7 +35,7 @@
     },
     "/apikeys/v1/inheritApiKeySetting": {
       "post": {
-        "operationId": "ApikeysInheritApiKeySetting",
+        "operationId": "ApikeysV1InheritApiKeySetting",
         "parameters": [],
         "responses": {
           "200": {
@@ -51,7 +51,7 @@
     },
     "/apikeys/v1/overrideApiKeySetting": {
       "post": {
-        "operationId": "ApikeysOverrideApiKeySetting",
+        "operationId": "ApikeysV1OverrideApiKeySetting",
         "parameters": [],
         "responses": {
           "200": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/array_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/array_endpoint.swagger
@@ -18,7 +18,7 @@
   "paths": {
     "/myapi/v1/arrayendpoint": {
       "get": {
-        "operationId": "MyapiGetArrayService",
+        "operationId": "MyapiV1GetArrayService",
         "parameters": [],
         "responses": {
           "200": {
@@ -32,7 +32,7 @@
     },
     "/myapi/v1/baz": {
       "get": {
-        "operationId": "MyapiGetBaz",
+        "operationId": "MyapiV1GetBaz",
         "parameters": [],
         "responses": {
           "200": {
@@ -46,7 +46,7 @@
     },
     "/myapi/v1/collectionresponse_foo": {
       "get": {
-        "operationId": "MyapiGetFoosResponse",
+        "operationId": "MyapiV1GetFoosResponse",
         "parameters": [],
         "responses": {
           "200": {
@@ -60,7 +60,7 @@
     },
     "/myapi/v1/foocollection": {
       "get": {
-        "operationId": "MyapiGetFoos",
+        "operationId": "MyapiV1GetFoos",
         "parameters": [],
         "responses": {
           "200": {
@@ -74,7 +74,7 @@
     },
     "/myapi/v1/foocollectioncollection": {
       "get": {
-        "operationId": "MyapiGetAllArrayedFoos",
+        "operationId": "MyapiV1GetAllArrayedFoos",
         "parameters": [],
         "responses": {
           "200": {
@@ -88,7 +88,7 @@
     },
     "/myapi/v1/getAllFoos": {
       "get": {
-        "operationId": "MyapiGetAllFoos",
+        "operationId": "MyapiV1GetAllFoos",
         "parameters": [],
         "responses": {
           "200": {
@@ -102,7 +102,7 @@
     },
     "/myapi/v1/getAllFoosResponse": {
       "get": {
-        "operationId": "MyapiGetAllFoosResponse",
+        "operationId": "MyapiV1GetAllFoosResponse",
         "parameters": [],
         "responses": {
           "200": {
@@ -116,7 +116,7 @@
     },
     "/myapi/v1/getAllNestedFoosResponse": {
       "get": {
-        "operationId": "MyapiGetAllNestedFoosResponse",
+        "operationId": "MyapiV1GetAllNestedFoosResponse",
         "parameters": [],
         "responses": {
           "200": {
@@ -130,7 +130,7 @@
     },
     "/myapi/v1/getArrayedFoos": {
       "get": {
-        "operationId": "MyapiGetArrayedFoos",
+        "operationId": "MyapiV1GetArrayedFoos",
         "parameters": [],
         "responses": {
           "200": {
@@ -144,7 +144,7 @@
     },
     "/myapi/v1/getIntegersResponse": {
       "get": {
-        "operationId": "MyapiGetIntegersResponse",
+        "operationId": "MyapiV1GetIntegersResponse",
         "parameters": [],
         "responses": {
           "200": {
@@ -158,7 +158,7 @@
     },
     "/myapi/v1/getListOfString": {
       "get": {
-        "operationId": "MyapiGetListOfString",
+        "operationId": "MyapiV1GetListOfString",
         "parameters": [],
         "responses": {
           "200": {
@@ -172,7 +172,7 @@
     },
     "/myapi/v1/getObjectIntegers": {
       "get": {
-        "operationId": "MyapiGetObjectIntegers",
+        "operationId": "MyapiV1GetObjectIntegers",
         "parameters": [],
         "responses": {
           "200": {
@@ -186,7 +186,7 @@
     },
     "/myapi/v1/integercollection": {
       "get": {
-        "operationId": "MyapiGetIntegers",
+        "operationId": "MyapiV1GetIntegers",
         "parameters": [],
         "responses": {
           "200": {
@@ -255,6 +255,20 @@
         }
       }
     },
+    "Baz": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "$ref": "#/definitions/Foo"
+        },
+        "foos": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Foo"
+          }
+        }
+      }
+    },
     "ListContainer": {
       "type": "object",
       "properties": {
@@ -266,16 +280,14 @@
         }
       }
     },
-    "Baz": {
+    "IntegerCollection": {
       "type": "object",
       "properties": {
-        "foo": {
-          "$ref": "#/definitions/Foo"
-        },
-        "foos": {
+        "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Foo"
+            "type": "integer",
+            "format": "int32"
           }
         }
       }
@@ -367,14 +379,13 @@
         }
       }
     },
-    "IntegerCollection": {
+    "FooCollection": {
       "type": "object",
       "properties": {
         "items": {
           "type": "array",
           "items": {
-            "type": "integer",
-            "format": "int32"
+            "$ref": "#/definitions/Foo"
           }
         }
       }
@@ -396,17 +407,6 @@
         },
         "nextPageToken": {
           "type": "string"
-        }
-      }
-    },
-    "FooCollection": {
-      "type": "object",
-      "properties": {
-        "items": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Foo"
-          }
         }
       }
     }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/enum_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/enum_endpoint.swagger
@@ -18,7 +18,7 @@
   "paths": {
     "/enum/v1/{value}": {
       "post": {
-        "operationId": "EnumCreate",
+        "operationId": "EnumV1Create",
         "parameters": [
           {
             "name": "value",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint.swagger
@@ -19,7 +19,7 @@
     "/foo/v1/foos": {
       "get": {
         "description": "list desc",
-        "operationId": "FooListFoos",
+        "operationId": "FooV1ListFoos",
         "parameters": [
           {
             "name": "n",
@@ -47,7 +47,7 @@
         ]
       },
       "post": {
-        "operationId": "FooToplevel",
+        "operationId": "FooV1Toplevel",
         "parameters": [],
         "responses": {
           "200": {
@@ -70,7 +70,7 @@
     "/foo/v1/foos/{id}": {
       "get": {
         "description": "get desc",
-        "operationId": "FooGetFoo",
+        "operationId": "FooV1GetFoo",
         "parameters": [
           {
             "name": "id",
@@ -99,7 +99,7 @@
       },
       "post": {
         "description": "update desc",
-        "operationId": "FooUpdateFoo",
+        "operationId": "FooV1UpdateFoo",
         "parameters": [
           {
             "name": "id",
@@ -136,7 +136,7 @@
       },
       "put": {
         "description": "create desc",
-        "operationId": "FooCreateFoo",
+        "operationId": "FooV1CreateFoo",
         "parameters": [
           {
             "name": "id",
@@ -173,7 +173,7 @@
       },
       "delete": {
         "description": "delete desc",
-        "operationId": "FooDeleteFoo",
+        "operationId": "FooV1DeleteFoo",
         "parameters": [
           {
             "name": "id",
@@ -221,6 +221,18 @@
     }
   },
   "definitions": {
+    "Foo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
     "CollectionResponse_Foo": {
       "type": "object",
       "properties": {
@@ -232,18 +244,6 @@
         },
         "nextPageToken": {
           "type": "string"
-        }
-      }
-    },
-    "Foo": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "value": {
-          "type": "integer",
-          "format": "int32"
         }
       }
     }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_default_context.swagger
@@ -19,7 +19,7 @@
     "/foo/v1/foos": {
       "get": {
         "description": "list desc",
-        "operationId": "FooListFoos",
+        "operationId": "FooV1ListFoos",
         "parameters": [
           {
             "name": "n",
@@ -47,7 +47,7 @@
         ]
       },
       "post": {
-        "operationId": "FooToplevel",
+        "operationId": "FooV1Toplevel",
         "parameters": [],
         "responses": {
           "200": {
@@ -70,7 +70,7 @@
     "/foo/v1/foos/{id}": {
       "get": {
         "description": "get desc",
-        "operationId": "FooGetFoo",
+        "operationId": "FooV1GetFoo",
         "parameters": [
           {
             "name": "id",
@@ -99,7 +99,7 @@
       },
       "post": {
         "description": "update desc",
-        "operationId": "FooUpdateFoo",
+        "operationId": "FooV1UpdateFoo",
         "parameters": [
           {
             "name": "id",
@@ -136,7 +136,7 @@
       },
       "put": {
         "description": "create desc",
-        "operationId": "FooCreateFoo",
+        "operationId": "FooV1CreateFoo",
         "parameters": [
           {
             "name": "id",
@@ -173,7 +173,7 @@
       },
       "delete": {
         "description": "delete desc",
-        "operationId": "FooDeleteFoo",
+        "operationId": "FooV1DeleteFoo",
         "parameters": [
           {
             "name": "id",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_internal.swagger
@@ -19,7 +19,7 @@
     "/foo/v1/foos": {
       "get": {
         "description": "list desc",
-        "operationId": "FooListFoos",
+        "operationId": "FooV1ListFoos",
         "parameters": [
           {
             "name": "n",
@@ -47,7 +47,7 @@
         ]
       },
       "post": {
-        "operationId": "FooToplevel",
+        "operationId": "FooV1Toplevel",
         "parameters": [],
         "responses": {
           "200": {
@@ -70,7 +70,7 @@
     "/foo/v1/foos/{id}": {
       "get": {
         "description": "get desc",
-        "operationId": "FooGetFoo",
+        "operationId": "FooV1GetFoo",
         "parameters": [
           {
             "name": "id",
@@ -99,7 +99,7 @@
       },
       "post": {
         "description": "update desc",
-        "operationId": "FooUpdateFoo",
+        "operationId": "FooV1UpdateFoo",
         "parameters": [
           {
             "name": "id",
@@ -136,7 +136,7 @@
       },
       "put": {
         "description": "create desc",
-        "operationId": "FooCreateFoo",
+        "operationId": "FooV1CreateFoo",
         "parameters": [
           {
             "name": "id",
@@ -173,7 +173,7 @@
       },
       "delete": {
         "description": "delete desc",
-        "operationId": "FooDeleteFoo",
+        "operationId": "FooV1DeleteFoo",
         "parameters": [
           {
             "name": "id",

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_endpoint_localhost.swagger
@@ -19,7 +19,7 @@
     "/foo/v1/foos": {
       "get": {
         "description": "list desc",
-        "operationId": "FooListFoos",
+        "operationId": "FooV1ListFoos",
         "parameters": [
           {
             "name": "n",
@@ -47,7 +47,7 @@
         ]
       },
       "post": {
-        "operationId": "FooToplevel",
+        "operationId": "FooV1Toplevel",
         "parameters": [],
         "responses": {
           "200": {
@@ -70,7 +70,7 @@
     "/foo/v1/foos/{id}": {
       "get": {
         "description": "get desc",
-        "operationId": "FooGetFoo",
+        "operationId": "FooV1GetFoo",
         "parameters": [
           {
             "name": "id",
@@ -99,7 +99,7 @@
       },
       "post": {
         "description": "update desc",
-        "operationId": "FooUpdateFoo",
+        "operationId": "FooV1UpdateFoo",
         "parameters": [
           {
             "name": "id",
@@ -136,7 +136,7 @@
       },
       "put": {
         "description": "create desc",
-        "operationId": "FooCreateFoo",
+        "operationId": "FooV1CreateFoo",
         "parameters": [
           {
             "name": "id",
@@ -173,7 +173,7 @@
       },
       "delete": {
         "description": "delete desc",
-        "operationId": "FooDeleteFoo",
+        "operationId": "FooV1DeleteFoo",
         "parameters": [
           {
             "name": "id",
@@ -221,6 +221,18 @@
     }
   },
   "definitions": {
+    "Foo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
     "CollectionResponse_Foo": {
       "type": "object",
       "properties": {
@@ -232,18 +244,6 @@
         },
         "nextPageToken": {
           "type": "string"
-        }
-      }
-    },
-    "Foo": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "value": {
-          "type": "integer",
-          "format": "int32"
         }
       }
     }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_with_description_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/foo_with_description_endpoint.swagger
@@ -19,7 +19,7 @@
     "/foo/v1/foos": {
       "get": {
         "description": "list desc",
-        "operationId": "FooListFoos",
+        "operationId": "FooV1ListFoos",
         "parameters": [
           {
             "name": "n",
@@ -58,7 +58,7 @@
         ]
       },
       "post": {
-        "operationId": "FooToplevel",
+        "operationId": "FooV1Toplevel",
         "parameters": [],
         "responses": {
           "200": {
@@ -81,7 +81,7 @@
     "/foo/v1/foos/{id}": {
       "get": {
         "description": "get desc",
-        "operationId": "FooGetFoo",
+        "operationId": "FooV1GetFoo",
         "parameters": [
           {
             "name": "id",
@@ -110,7 +110,7 @@
       },
       "post": {
         "description": "update desc",
-        "operationId": "FooUpdateFoo",
+        "operationId": "FooV1UpdateFoo",
         "parameters": [
           {
             "name": "id",
@@ -147,7 +147,7 @@
       },
       "put": {
         "description": "create desc",
-        "operationId": "FooCreateFoo",
+        "operationId": "FooV1CreateFoo",
         "parameters": [
           {
             "name": "id",
@@ -184,7 +184,7 @@
       },
       "delete": {
         "description": "delete desc",
-        "operationId": "FooDeleteFoo",
+        "operationId": "FooV1DeleteFoo",
         "parameters": [
           {
             "name": "id",
@@ -232,20 +232,6 @@
     }
   },
   "definitions": {
-    "CollectionResponse_FooDescription": {
-      "type": "object",
-      "properties": {
-        "items": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/FooDescription"
-          }
-        },
-        "nextPageToken": {
-          "type": "string"
-        }
-      }
-    },
     "FooDescription": {
       "type": "object",
       "properties": {
@@ -265,6 +251,20 @@
           "type": "integer",
           "format": "int32",
           "description": "description of value"
+        }
+      }
+    },
+    "CollectionResponse_FooDescription": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FooDescription"
+          }
+        },
+        "nextPageToken": {
+          "type": "string"
         }
       }
     }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/google_auth.swagger
@@ -18,7 +18,7 @@
   "paths": {
     "/thirdparty/v1/authOverride": {
       "post": {
-        "operationId": "ThirdpartyAuthOverride",
+        "operationId": "ThirdpartyV1AuthOverride",
         "parameters": [],
         "responses": {
           "200": {
@@ -34,7 +34,7 @@
     },
     "/thirdparty/v1/googleAuth": {
       "post": {
-        "operationId": "ThirdpartyGoogleAuth",
+        "operationId": "ThirdpartyV1GoogleAuth",
         "parameters": [],
         "responses": {
           "200": {
@@ -50,7 +50,7 @@
     },
     "/thirdparty/v1/noOverride": {
       "post": {
-        "operationId": "ThirdpartyNoOverride",
+        "operationId": "ThirdpartyV1NoOverride",
         "parameters": [],
         "responses": {
           "200": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/limit_metrics_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/limit_metrics_endpoint.swagger
@@ -18,7 +18,7 @@
   "paths": {
     "/limits/v1/create": {
       "post": {
-        "operationId": "LimitsCreateFoo",
+        "operationId": "LimitsV1CreateFoo",
         "parameters": [],
         "responses": {
           "200": {
@@ -37,7 +37,7 @@
     },
     "/limits/v1/customFoo": {
       "post": {
-        "operationId": "LimitsCustomFoo",
+        "operationId": "LimitsV1CustomFoo",
         "parameters": [],
         "responses": {
           "200": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint.swagger
@@ -18,7 +18,7 @@
   "paths": {
     "/myapi/v1/getDateTimeKeyMap": {
       "get": {
-        "operationId": "MyapiGetDateTimeKeyMap",
+        "operationId": "MyapiV1GetDateTimeKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -32,7 +32,7 @@
     },
     "/myapi/v1/getMapOfStrings": {
       "get": {
-        "operationId": "MyapiGetMapOfStrings",
+        "operationId": "MyapiV1GetMapOfStrings",
         "parameters": [],
         "responses": {
           "200": {
@@ -46,7 +46,7 @@
     },
     "/myapi/v1/getStringCollectionMap": {
       "get": {
-        "operationId": "MyapiGetStringCollectionMap",
+        "operationId": "MyapiV1GetStringCollectionMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -60,7 +60,7 @@
     },
     "/myapi/v1/map_boolean_string": {
       "get": {
-        "operationId": "MyapiGetBooleanKeyMap",
+        "operationId": "MyapiV1GetBooleanKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -74,7 +74,7 @@
     },
     "/myapi/v1/map_datetime_string": {
       "get": {
-        "operationId": "MyapiGetDateKeyMap",
+        "operationId": "MyapiV1GetDateKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -88,7 +88,7 @@
     },
     "/myapi/v1/map_float_string": {
       "get": {
-        "operationId": "MyapiGetFloatKeyMap",
+        "operationId": "MyapiV1GetFloatKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -102,7 +102,7 @@
     },
     "/myapi/v1/map_integer_string": {
       "get": {
-        "operationId": "MyapiGetIntKeyMap",
+        "operationId": "MyapiV1GetIntKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -116,7 +116,7 @@
     },
     "/myapi/v1/map_long_string": {
       "get": {
-        "operationId": "MyapiGetLongKeyMap",
+        "operationId": "MyapiV1GetLongKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -130,7 +130,7 @@
     },
     "/myapi/v1/map_string_baz": {
       "get": {
-        "operationId": "MyapiGetBazMap",
+        "operationId": "MyapiV1GetBazMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -144,7 +144,7 @@
     },
     "/myapi/v1/map_string_foo": {
       "get": {
-        "operationId": "MyapiGetFooMap",
+        "operationId": "MyapiV1GetFooMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -158,7 +158,7 @@
     },
     "/myapi/v1/map_string_integer": {
       "get": {
-        "operationId": "MyapiGetIntMap",
+        "operationId": "MyapiV1GetIntMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -172,7 +172,7 @@
     },
     "/myapi/v1/map_string_map_string_foo": {
       "get": {
-        "operationId": "MyapiGetFooMapMap",
+        "operationId": "MyapiV1GetFooMapMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -186,7 +186,7 @@
     },
     "/myapi/v1/map_string_string": {
       "get": {
-        "operationId": "MyapiGetStringMap",
+        "operationId": "MyapiV1GetStringMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -200,7 +200,7 @@
     },
     "/myapi/v1/map_string_stringcollection": {
       "get": {
-        "operationId": "MyapiGetStringArrayMap",
+        "operationId": "MyapiV1GetStringArrayMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -214,7 +214,7 @@
     },
     "/myapi/v1/map_string_stringvalue": {
       "get": {
-        "operationId": "MyapiGetStringValueMap",
+        "operationId": "MyapiV1GetStringValueMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -228,7 +228,7 @@
     },
     "/myapi/v1/map_testenum_string": {
       "get": {
-        "operationId": "MyapiGetEnumKeyMap",
+        "operationId": "MyapiV1GetEnumKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -242,7 +242,7 @@
     },
     "/myapi/v1/mapendpoint": {
       "get": {
-        "operationId": "MyapiGetMapService",
+        "operationId": "MyapiV1GetMapService",
         "parameters": [],
         "responses": {
           "200": {
@@ -256,7 +256,7 @@
     },
     "/myapi/v1/mapsubclass": {
       "get": {
-        "operationId": "MyapiGetMapSubclass",
+        "operationId": "MyapiV1GetMapSubclass",
         "parameters": [],
         "responses": {
           "200": {
@@ -306,15 +306,15 @@
         "type": "string"
       }
     },
-    "JsonMap": {
-      "type": "object"
-    },
     "Map_Boolean_Integer": {
       "type": "object",
       "additionalProperties": {
         "type": "integer",
         "format": "int32"
       }
+    },
+    "JsonMap": {
+      "type": "object"
     },
     "Map_String_StringValue": {
       "type": "object",
@@ -337,16 +337,16 @@
         "format": "int32"
       }
     },
-    "Map_String_Map_String_Foo": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/Map_String_Foo"
-      }
-    },
     "Map_String_Baz": {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Baz"
+      }
+    },
+    "Map_String_Map_String_Foo": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Map_String_Foo"
       }
     },
     "Map_String_String": {
@@ -434,17 +434,18 @@
         }
       }
     },
-    "Map_DateTime_String": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
-    },
     "Map_String_Foo": {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Foo"
       }
+    },
+    "Map_DateTime_String": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   }
 }
+

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_legacy.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_legacy.swagger
@@ -18,7 +18,7 @@
   "paths": {
     "/myapi/v1/getDateTimeKeyMap": {
       "get": {
-        "operationId": "MyapiGetDateTimeKeyMap",
+        "operationId": "MyapiV1GetDateTimeKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -32,7 +32,7 @@
     },
     "/myapi/v1/getMapOfStrings": {
       "get": {
-        "operationId": "MyapiGetMapOfStrings",
+        "operationId": "MyapiV1GetMapOfStrings",
         "parameters": [],
         "responses": {
           "200": {
@@ -46,7 +46,7 @@
     },
     "/myapi/v1/getStringCollectionMap": {
       "get": {
-        "operationId": "MyapiGetStringCollectionMap",
+        "operationId": "MyapiV1GetStringCollectionMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -60,7 +60,7 @@
     },
     "/myapi/v1/map_boolean_string": {
       "get": {
-        "operationId": "MyapiGetBooleanKeyMap",
+        "operationId": "MyapiV1GetBooleanKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -74,7 +74,7 @@
     },
     "/myapi/v1/map_datetime_string": {
       "get": {
-        "operationId": "MyapiGetDateKeyMap",
+        "operationId": "MyapiV1GetDateKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -88,7 +88,7 @@
     },
     "/myapi/v1/map_float_string": {
       "get": {
-        "operationId": "MyapiGetFloatKeyMap",
+        "operationId": "MyapiV1GetFloatKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -102,7 +102,7 @@
     },
     "/myapi/v1/map_integer_string": {
       "get": {
-        "operationId": "MyapiGetIntKeyMap",
+        "operationId": "MyapiV1GetIntKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -116,7 +116,7 @@
     },
     "/myapi/v1/map_long_string": {
       "get": {
-        "operationId": "MyapiGetLongKeyMap",
+        "operationId": "MyapiV1GetLongKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -130,7 +130,7 @@
     },
     "/myapi/v1/map_string_baz": {
       "get": {
-        "operationId": "MyapiGetBazMap",
+        "operationId": "MyapiV1GetBazMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -144,7 +144,7 @@
     },
     "/myapi/v1/map_string_foo": {
       "get": {
-        "operationId": "MyapiGetFooMap",
+        "operationId": "MyapiV1GetFooMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -158,7 +158,7 @@
     },
     "/myapi/v1/map_string_integer": {
       "get": {
-        "operationId": "MyapiGetIntMap",
+        "operationId": "MyapiV1GetIntMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -172,7 +172,7 @@
     },
     "/myapi/v1/map_string_map_string_foo": {
       "get": {
-        "operationId": "MyapiGetFooMapMap",
+        "operationId": "MyapiV1GetFooMapMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -186,7 +186,7 @@
     },
     "/myapi/v1/map_string_string": {
       "get": {
-        "operationId": "MyapiGetStringMap",
+        "operationId": "MyapiV1GetStringMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -200,7 +200,7 @@
     },
     "/myapi/v1/map_string_stringcollection": {
       "get": {
-        "operationId": "MyapiGetStringArrayMap",
+        "operationId": "MyapiV1GetStringArrayMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -214,7 +214,7 @@
     },
     "/myapi/v1/map_string_stringvalue": {
       "get": {
-        "operationId": "MyapiGetStringValueMap",
+        "operationId": "MyapiV1GetStringValueMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -228,7 +228,7 @@
     },
     "/myapi/v1/map_testenum_string": {
       "get": {
-        "operationId": "MyapiGetEnumKeyMap",
+        "operationId": "MyapiV1GetEnumKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -242,7 +242,7 @@
     },
     "/myapi/v1/mapendpoint": {
       "get": {
-        "operationId": "MyapiGetMapService",
+        "operationId": "MyapiV1GetMapService",
         "parameters": [],
         "responses": {
           "200": {
@@ -256,7 +256,7 @@
     },
     "/myapi/v1/mapsubclass": {
       "get": {
-        "operationId": "MyapiGetMapSubclass",
+        "operationId": "MyapiV1GetMapSubclass",
         "parameters": [],
         "responses": {
           "200": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_with_array.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/map_endpoint_with_array.swagger
@@ -18,7 +18,7 @@
   "paths": {
     "/myapi/v1/getDateTimeKeyMap": {
       "get": {
-        "operationId": "MyapiGetDateTimeKeyMap",
+        "operationId": "MyapiV1GetDateTimeKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -32,7 +32,7 @@
     },
     "/myapi/v1/getMapOfStrings": {
       "get": {
-        "operationId": "MyapiGetMapOfStrings",
+        "operationId": "MyapiV1GetMapOfStrings",
         "parameters": [],
         "responses": {
           "200": {
@@ -46,7 +46,7 @@
     },
     "/myapi/v1/getStringCollectionMap": {
       "get": {
-        "operationId": "MyapiGetStringCollectionMap",
+        "operationId": "MyapiV1GetStringCollectionMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -60,7 +60,7 @@
     },
     "/myapi/v1/map_boolean_string": {
       "get": {
-        "operationId": "MyapiGetBooleanKeyMap",
+        "operationId": "MyapiV1GetBooleanKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -74,7 +74,7 @@
     },
     "/myapi/v1/map_datetime_string": {
       "get": {
-        "operationId": "MyapiGetDateKeyMap",
+        "operationId": "MyapiV1GetDateKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -88,7 +88,7 @@
     },
     "/myapi/v1/map_float_string": {
       "get": {
-        "operationId": "MyapiGetFloatKeyMap",
+        "operationId": "MyapiV1GetFloatKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -102,7 +102,7 @@
     },
     "/myapi/v1/map_integer_string": {
       "get": {
-        "operationId": "MyapiGetIntKeyMap",
+        "operationId": "MyapiV1GetIntKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -116,7 +116,7 @@
     },
     "/myapi/v1/map_long_string": {
       "get": {
-        "operationId": "MyapiGetLongKeyMap",
+        "operationId": "MyapiV1GetLongKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -130,7 +130,7 @@
     },
     "/myapi/v1/map_string_baz": {
       "get": {
-        "operationId": "MyapiGetBazMap",
+        "operationId": "MyapiV1GetBazMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -144,7 +144,7 @@
     },
     "/myapi/v1/map_string_foo": {
       "get": {
-        "operationId": "MyapiGetFooMap",
+        "operationId": "MyapiV1GetFooMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -158,7 +158,7 @@
     },
     "/myapi/v1/map_string_integer": {
       "get": {
-        "operationId": "MyapiGetIntMap",
+        "operationId": "MyapiV1GetIntMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -172,7 +172,7 @@
     },
     "/myapi/v1/map_string_map_string_foo": {
       "get": {
-        "operationId": "MyapiGetFooMapMap",
+        "operationId": "MyapiV1GetFooMapMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -186,7 +186,7 @@
     },
     "/myapi/v1/map_string_string": {
       "get": {
-        "operationId": "MyapiGetStringMap",
+        "operationId": "MyapiV1GetStringMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -200,7 +200,7 @@
     },
     "/myapi/v1/map_string_stringcollection": {
       "get": {
-        "operationId": "MyapiGetStringArrayMap",
+        "operationId": "MyapiV1GetStringArrayMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -214,7 +214,7 @@
     },
     "/myapi/v1/map_string_stringvalue": {
       "get": {
-        "operationId": "MyapiGetStringValueMap",
+        "operationId": "MyapiV1GetStringValueMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -228,7 +228,7 @@
     },
     "/myapi/v1/map_testenum_string": {
       "get": {
-        "operationId": "MyapiGetEnumKeyMap",
+        "operationId": "MyapiV1GetEnumKeyMap",
         "parameters": [],
         "responses": {
           "200": {
@@ -242,7 +242,7 @@
     },
     "/myapi/v1/mapendpoint": {
       "get": {
-        "operationId": "MyapiGetMapService",
+        "operationId": "MyapiV1GetMapService",
         "parameters": [],
         "responses": {
           "200": {
@@ -256,7 +256,7 @@
     },
     "/myapi/v1/mapsubclass": {
       "get": {
-        "operationId": "MyapiGetMapSubclass",
+        "operationId": "MyapiV1GetMapSubclass",
         "parameters": [],
         "responses": {
           "200": {
@@ -334,16 +334,16 @@
         "format": "int32"
       }
     },
-    "Map_String_Map_String_Foo": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/Map_String_Foo"
-      }
-    },
     "Map_String_Baz": {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Baz"
+      }
+    },
+    "Map_String_Map_String_Foo": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/Map_String_Foo"
       }
     },
     "Map_String_String": {
@@ -440,16 +440,16 @@
         }
       }
     },
-    "Map_DateTime_String": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
-    },
     "Map_String_Foo": {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Foo"
+      }
+    },
+    "Map_DateTime_String": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
       }
     }
   }

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_resource_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_resource_endpoint.swagger
@@ -2,10 +2,10 @@
   "swagger": "2.0",
   "info": {
     "version": "1.0.0",
-    "title": "myapi.appspot.com"
+    "title": "swagger-test.appspot.com"
   },
-  "host": "myapi.appspot.com",
-  "basePath": "/_ah/api",
+  "host": "swagger-test.appspot.com",
+  "basePath": "/api",
   "schemes": [
     "https"
   ],
@@ -16,20 +16,37 @@
     "application/json"
   ],
   "paths": {
-    "/absolutepath/v1/absolutepathmethod": {
-      "post": {
-        "operationId": "AbsolutepathV1AbsolutePath",
+    "/multiresource/v1/noresource": {
+      "get": {
+        "operationId": "MultiresourceV1Get",
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response"
+            "description": "A successful response",
+            "schema": {
+              "$ref": "#/definitions/Foo"
+            }
           }
         }
       }
     },
-    "/absolutepath/v1/create": {
-      "post": {
-        "operationId": "AbsolutepathV1CreateFoo",
+    "/multiresource/v1/resource1": {
+      "get": {
+        "operationId": "MultiresourceV1Resource1Get",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "schema": {
+              "$ref": "#/definitions/Foo"
+            }
+          }
+        }
+      }
+    },
+    "/multiresource/v1/resource2": {
+      "get": {
+        "operationId": "MultiresourceV1Resource2Get",
         "parameters": [],
         "responses": {
           "200": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_version_endpoint.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/multi_version_endpoint.swagger
@@ -2,10 +2,10 @@
   "swagger": "2.0",
   "info": {
     "version": "1.0.0",
-    "title": "myapi.appspot.com"
+    "title": "swagger-test.appspot.com"
   },
-  "host": "myapi.appspot.com",
-  "basePath": "/_ah/api",
+  "host": "swagger-test.appspot.com",
+  "basePath": "/api",
   "schemes": [
     "https"
   ],
@@ -16,20 +16,23 @@
     "application/json"
   ],
   "paths": {
-    "/absolutepath/v1/absolutepathmethod": {
-      "post": {
-        "operationId": "AbsolutepathV1AbsolutePath",
+    "/myapi/v1/foo": {
+      "get": {
+        "operationId": "MyapiV1Get",
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response"
+            "description": "A successful response",
+            "schema": {
+              "$ref": "#/definitions/Foo"
+            }
           }
         }
       }
     },
-    "/absolutepath/v1/create": {
-      "post": {
-        "operationId": "AbsolutepathV1CreateFoo",
+    "/myapi/v2/foo": {
+      "get": {
+        "operationId": "MyapiV2Get",
         "parameters": [],
         "responses": {
           "200": {

--- a/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/third_party_auth.swagger
+++ b/endpoints-framework/src/test/resources/com/google/api/server/spi/swagger/third_party_auth.swagger
@@ -18,7 +18,7 @@
   "paths": {
     "/thirdparty/v1/authOverride": {
       "post": {
-        "operationId": "ThirdpartyAuthOverride",
+        "operationId": "ThirdpartyV1AuthOverride",
         "parameters": [],
         "responses": {
           "200": {
@@ -34,7 +34,7 @@
     },
     "/thirdparty/v1/noOverride": {
       "post": {
-        "operationId": "ThirdpartyNoOverride",
+        "operationId": "ThirdpartyV1NoOverride",
         "parameters": [],
         "responses": {
           "200": {

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/MultiResourceEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/MultiResourceEndpoint.java
@@ -1,0 +1,47 @@
+package com.google.api.server.spi.testing;
+
+import com.google.api.server.spi.config.Api;
+import com.google.api.server.spi.config.ApiClass;
+import com.google.api.server.spi.config.ApiMethod;
+
+public class MultiResourceEndpoint {
+
+  @Api(
+      name = "multiresource",
+      version = "v1")
+  public static class NoResourceEndpoint {
+
+    @ApiMethod(path = "noresource")
+    public Foo get() {
+      return null;
+    }
+
+  }
+  
+  @Api(
+      name = "multiresource",
+      version = "v1")
+  @ApiClass(resource = "resource1")
+  public static class Resource1Endpoint {
+
+    @ApiMethod(path = "resource1")
+    public Foo get() {
+      return null;
+    }
+    
+  }
+
+  @Api(
+      name = "multiresource",
+      version = "v1")
+  @ApiClass(resource = "resource2")
+  public static class Resource2Endpoint {
+
+    @ApiMethod(path = "resource2")
+    public Foo get() {
+      return null;
+    }
+    
+  }
+
+}

--- a/test-utils/src/main/java/com/google/api/server/spi/testing/MultiVersionEndpoint.java
+++ b/test-utils/src/main/java/com/google/api/server/spi/testing/MultiVersionEndpoint.java
@@ -1,0 +1,31 @@
+package com.google.api.server.spi.testing;
+
+import com.google.api.server.spi.config.Api;
+import com.google.api.server.spi.config.ApiClass;
+import com.google.api.server.spi.config.ApiMethod;
+
+public class MultiVersionEndpoint {
+
+  @Api(
+      name = "myapi",
+      version = "v1")
+  public static class Version1Endpoint {
+
+    public Foo get() {
+      return null;
+    }
+
+  }
+  
+  @Api(
+      name = "myapi",
+      version = "v2")
+  public static class Version2Endpoint {
+
+    public Foo get() {
+      return null;
+    }
+    
+  }
+
+}


### PR DESCRIPTION
- Generate operation ids based on api name, version, resource name and method name to avoid conflicts
- Try to make generated swagger files identical over runs by using only order-preserving maps => useful when Swagger spec is generated on build and versioned