### PR TITLE
Inline Files.write() in GenApiConfigAction

### DIFF
--- a/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GenApiConfigAction.java
+++ b/endpoints-framework-tools/src/main/java/com/google/api/server/spi/tools/GenApiConfigAction.java
@@ -104,7 +104,7 @@ public class GenApiConfigAction extends EndpointsToolAction {
         String apiConfigFileName = entry.getKey();
         String apiConfigFileContent = entry.getValue();
         String apiConfigFilePath = outputDir + "/" + apiConfigFileName;
-        Files.write(apiConfigFileContent, new File(apiConfigFilePath), UTF_8);
+        Files.asCharSink(new File(apiConfigFilePath), UTF_8).write(apiConfigFileContent);
         System.out.println("API configuration written to " + apiConfigFilePath);
       }
     }


### PR DESCRIPTION
Files.write is deprecated and scheduled for removal. Changing this to use Files.asCharSink().write() is the same implementation, but is not deprecated.