### PR TITLE
Add extra fields in ServiceException

### DIFF
--- a/endpoints-framework/build.gradle
+++ b/endpoints-framework/build.gradle
@@ -110,6 +110,7 @@ dependencies {
   testCompile project(':test-utils')
   testCompile group: 'junit', name: 'junit', version: junitVersion
   testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+  testCompile group: 'org.skyscreamer', name: 'jsonassert', version: jsonassertVersion
   testCompile group: 'com.google.truth', name: 'truth', version: truthVersion
   testCompile group: 'com.google.appengine', name: 'appengine-testing', version: appengineVersion
   testCompile group: 'com.google.appengine', name: 'appengine-api-stubs', version: appengineVersion

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/ServiceException.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/ServiceException.java
@@ -15,6 +15,12 @@
  */
 package com.google.api.server.spi;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.flogger.FluentLogger;
+
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 
@@ -24,10 +30,16 @@ import java.util.logging.Level;
  */
 public class ServiceException extends Exception {
 
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  /** Reserved keywords, cannot be set as an extra field name. */
+  public static final ImmutableList<String> EXTRA_FIELDS_RESERVED_NAMES = ImmutableList.of("domain", "message", "reason");
+
   protected final int statusCode;
   protected final String reason;
   protected final String domain;
   protected Level logLevel;
+  private final Map<String, Object> extraFields = new HashMap<>();
 
   public ServiceException(int statusCode, String statusMessage) {
     super(statusMessage);
@@ -100,6 +112,64 @@ public class ServiceException extends Exception {
 
   public Map<String, String> getHeaders() {
     return null;
+  }
+
+  /**
+   * Associates to this exception an extra field as a field name/value pair. If a field
+   * with the same name was previously set, the old value is replaced by the specified
+   * value.
+   * @return this
+   * @throws NullPointerException if {@code fieldName} is {@code null}.
+   * @throws IllegalArgumentException if {@code fieldName} is one of the reserved field
+   *         names {@link #EXTRA_FIELDS_RESERVED_NAMES}.
+   */
+  public ServiceException putExtraField(String fieldName, String value) {
+    return putExtraFieldInternal(fieldName, value);
+  }
+
+  /**
+   * Associates to this exception an extra field as a field name/value pair. If a field
+   * with the same name was previously set, the old value is replaced by the specified
+   * value.
+   * @return this
+   * @throws NullPointerException if {@code fieldName} is {@code null}.
+   * @throws IllegalArgumentException if {@code fieldName} is one of the reserved field
+   *         names {@link #EXTRA_FIELDS_RESERVED_NAMES}.
+   */
+  public ServiceException putExtraField(String fieldName, Boolean value) {
+    return putExtraFieldInternal(fieldName, value);
+  }
+
+  /**
+   * Associates to this exception an extra field as a field name/value pair. If a field
+   * with the same name was previously set, the old value is replaced by the specified
+   * value.
+   * @return this
+   * @throws NullPointerException if {@code fieldName} is {@code null}.
+   * @throws IllegalArgumentException if {@code fieldName} is one of the reserved field
+   *         names {@link #EXTRA_FIELDS_RESERVED_NAMES}.
+   */
+  public ServiceException putExtraField(String fieldName, Number value) {
+    return putExtraFieldInternal(fieldName, value);
+  }
+
+  private ServiceException putExtraFieldInternal(String fieldName, Object value) {
+    Preconditions.checkNotNull(fieldName);
+    Preconditions.checkArgument(!EXTRA_FIELDS_RESERVED_NAMES.contains(fieldName), "The field name '%s' is reserved", fieldName);
+    final Object previousValue = extraFields.put(fieldName, value);
+    if (previousValue != null) {
+      logger.atFine().log("Replaced extra field %s: %s => %s", fieldName, previousValue, value);
+    }
+    return this;
+  }
+
+  /**
+   * Gets the extra fields. The extra fields are returned in an unmodifiable map,
+   * each field name/value pair is a map entry. The map is empty if no extra field
+   * has been added.
+   */
+  public final Map<String, Object> getExtraFields() {
+    return Collections.unmodifiableMap(extraFields);
   }
 
   public Level getLogLevel() {

--- a/endpoints-framework/src/main/java/com/google/api/server/spi/response/RestResponseResultWriter.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/response/RestResponseResultWriter.java
@@ -23,6 +23,7 @@ import com.google.api.server.spi.config.model.ApiSerializationConfig;
 import com.google.common.base.Strings;
 
 import java.io.IOException;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -67,16 +68,19 @@ public class RestResponseResultWriter extends ServletResponseResultWriter {
         e.getReason() : errorMap.getReason(e.getStatusCode());
     String domain = !Strings.isNullOrEmpty(e.getDomain()) ?
         e.getDomain() : errorMap.getDomain(e.getStatusCode());
-    write(code, e.getHeaders(), createError(code, reason, domain, e.getMessage()));
+    write(code, e.getHeaders(), createError(code, reason, domain, e.getMessage(), e.getExtraFields()));
   }
 
-  private Object createError(int code, String reason, String domain, String message) {
+  private Object createError(int code, String reason, String domain, String message, Map<String, Object> extraFields) {
     ObjectNode topLevel = objectMapper.createObjectNode();
     ObjectNode topError = objectMapper.createObjectNode();
     ObjectNode error = objectMapper.createObjectNode();
     error.put("domain", domain);
     error.put("reason", reason);
     error.put("message", message);
+    for (Map.Entry<String, Object> extraField : extraFields.entrySet()) {
+      error.putPOJO(extraField.getKey(), extraField.getValue());
+    }
     topError.set("errors", objectMapper.createArrayNode().add(error));
     topError.put("code", code);
     topError.put("message", message);

--- a/endpoints-framework/src/test/java/com/google/api/server/spi/ServiceExceptionTest.java
+++ b/endpoints-framework/src/test/java/com/google/api/server/spi/ServiceExceptionTest.java
@@ -1,20 +1,91 @@
 package com.google.api.server.spi;
 
 import static com.google.common.truth.Truth.assertThat;
+import static java.lang.Boolean.TRUE;
 
+import com.google.api.server.spi.response.BadRequestException;
+import com.google.api.server.spi.response.ConflictException;
 import com.google.api.server.spi.response.UnauthorizedException;
+
+import java.util.Map;
 import java.util.logging.Level;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ServiceExceptionTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
   @Test
   public void testWithLogLevel() {
     UnauthorizedException ex = new UnauthorizedException("");
     assertThat(ex.getLogLevel()).isEqualTo(Level.INFO);
     assertThat(ServiceException.withLogLevel(ex, Level.WARNING).getLogLevel())
         .isEqualTo(Level.WARNING);
+  }
+
+  @Test
+  public void testExtraFields() {
+    UnauthorizedException ex = new UnauthorizedException("");
+    ex.putExtraField("isAdmin", TRUE)
+      .putExtraField("userId", Integer.valueOf(12))
+      .putExtraField("userName", "John Doe");
+    Map<String, Object> extraFields = ex.getExtraFields();
+    assertThat(extraFields.size()).isEqualTo(3);
+    assertThat(extraFields.get("isAdmin")).isEqualTo(TRUE);
+    assertThat(extraFields.get("userId")).isEqualTo(12);
+    assertThat(extraFields.get("userName")).isEqualTo("John Doe");
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testExtraFields_nameNull() {
+    new BadRequestException("").putExtraField(null, "value not null");
+  }
+
+  @Test
+  public void testExtraFields_valueNull_allowed() {
+    UnauthorizedException ex = new UnauthorizedException("");
+    ex.putExtraField("isAdmin", (String) null);
+    Map<String, Object> extraFields = ex.getExtraFields();
+    assertThat(extraFields.size()).isEqualTo(1);
+    assertThat(extraFields.get("isAdmin")).isNull();
+  }
+
+  @Test
+  public void testExtraFields_overrideValue_keepLast() {
+    UnauthorizedException ex = new UnauthorizedException("");
+    ex.putExtraField("isAdmin", "YES");
+    ex.putExtraField("isAdmin", TRUE);
+    Map<String, Object> extraFields = ex.getExtraFields();
+    assertThat(extraFields.size()).isEqualTo(1);
+    assertThat(extraFields.get("isAdmin")).isEqualTo(TRUE);
+  }
+
+  @Test
+  public void testExtraFields_ReservedNameDomain_forbidden() {
+    assertExtraFields_ReservedName_forbidden("domain");
+  }
+
+  @Test
+  public void testExtraFields_ReservedNameMessage_forbidden() {
+    assertExtraFields_ReservedName_forbidden("message");
+  }
+
+  @Test
+  public void testExtraFields_ReservedNameReason_forbidden() {
+    assertExtraFields_ReservedName_forbidden("reason");
+  }
+
+  private void assertExtraFields_ReservedName_forbidden(String fieldName) {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("The field name '" + fieldName + "' is reserved");
+
+    new ConflictException("Fails", "no extra " + fieldName).putExtraField(fieldName, "some other " + fieldName);
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,6 @@ floggerVersion=0.3.1
 
 junitVersion=4.12
 mockitoVersion=1.10.19
+jsonassertVersion=1.5.0
 truthVersion=0.28
 springtestVersion=3.2.16.RELEASE


### PR DESCRIPTION
The goal of these changes is to be able to add some extra fields in ServiceException, to give more details about the error. These fields may be documented by the service and used on the client side (diagnosis, help, ...).

For example, the field 'extendedHelp' in this reply
```
{
 "code" : 403,
 "errors" :
  [ {
    "domain" : "usageLimits",
    "message" : "User Rate Limit Exceeded. Rate of requests for user exceed configured project quota. You may consider re-evaluating expected per-user traffic to the API and adjust project quota limits accordingly. You may monitor aggregate quota usage and adjust limits in the API Console: https://console.developers.google.com/apis/api/drive.googleapis.com/quotas?project=xyz",
    "reason" : "userRateLimitExceeded",
    "extendedHelp" : "https://console.developers.google.com/apis/api/drive.googleapis.com/quotas?project=xyz"
  } ],
  "message" : "User Rate Limit Exceeded. Rate of requests for user exceed configured project quota. You may consider re-evaluating expected per-user traffic to the API and adjust project quota limits accordingly. You may monitor aggregate quota usage and adjust limits in the API Console: https://console.developers.google.com/apis/api/drive.googleapis.com/quotas?project=xyz"
}
```
