### PR TITLE
Fix JacksonResourceSchemaProvider to work with both the older and newer jackson versions.

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/config/jsonwriter/JacksonResourceSchemaProvider.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/config/jsonwriter/JacksonResourceSchemaProvider.java
@@ -128,7 +128,7 @@ public class JacksonResourceSchemaProvider extends AbstractResourceSchemaProvide
       }
     } else if (field != null) {
       return ApiAnnotationIntrospector.getSchemaType(
-          beanType.resolveType(field.getGenericType()), config);
+          beanType.resolveType(field.getAnnotated().getGenericType()), config);
     }
     return null;
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.0.16
+version=2.0.17
 
 sourceCompatibility=1.7
 targetCompatibility=1.7


### PR DESCRIPTION
`getGenericType()` method has been deprecated and removed in the newer jackson2 version. This fix allows things to work with the newer jackson2 version as well.