### PR TITLE
Turn ServiceException into an UncheckedException

### DIFF
--- a/endpoints-framework/src/main/java/com/google/api/server/spi/ServiceException.java
+++ b/endpoints-framework/src/main/java/com/google/api/server/spi/ServiceException.java
@@ -22,7 +22,7 @@ import java.util.logging.Level;
  * Generic service exception that, in addition to a status message, has a status code, and
  * optionally, response headers to return.
  */
-public class ServiceException extends Exception {
+public class ServiceException extends RuntimeException {
 
   protected final int statusCode;
   protected final String reason;


### PR DESCRIPTION
From Effective Java Item 71: Avoid unnecessary use of checked exceptions
"overuse of checked exceptions in APIs can make them far less pleasant to use. If a method throws checked exceptions, the code that invokes it must handle them in one or more catch blocks, or declare that it throws them and let them propagate outward. Either way, it places a burden on the user of the API. The burden increased in Java 8, as methods throwing checked exceptions can’t be used directly in streams (Items 45–48)."

In this API the outer Google Cloud Endpoints framework handles these ServiceExceptions, the developer is simply to detect other exceptions then wrap them in a ServiceException to throw up to the framework for proper error code response. If the code that throws the exception is a few levels deep the developer is forced to propagate throws ServiceException on all those methods. The developer is not supposed to handle these exceptions but allow the framework to handle them, thus they should not have to deal with that burden.